### PR TITLE
feat: add announcements module

### DIFF
--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -2,6 +2,7 @@
 import 'package:get/get_navigation/src/routes/get_route.dart';
 
 import '../../modules/splash/splash_view.dart';
+import '../../modules/announcement/views/announcement_list_view.dart';
 import '../../modules/auth/views/login_view.dart';
 import '../../modules/admin_dashboard/views/admin_dashboard_view.dart';
 import '../../modules/teachers_dashboard/views/teacher_dashboard_view.dart';
@@ -15,6 +16,9 @@ abstract class AppPages {
   static const ADMIN_CONTROL = '/admin/control';
   static const TEACHER_HOME = '/teacher';
   static const PARENT_HOME  = '/parent';
+  static const ADMIN_ANNOUNCEMENTS = '/admin/announcements';
+  static const TEACHER_ANNOUNCEMENTS = '/teacher/announcements';
+  static const PARENT_ANNOUNCEMENTS = '/parent/announcements';
 
   static final routes = [
     GetPage(name: SPLASH,      page: () => SplashView()),
@@ -23,5 +27,8 @@ abstract class AppPages {
     GetPage(name: ADMIN_CONTROL, page: () => AdminControlView()),
     GetPage(name: TEACHER_HOME,page: () => TeacherDashboard()),
     GetPage(name: PARENT_HOME, page: () => ParentDashboard()),
+    GetPage(name: ADMIN_ANNOUNCEMENTS, page: () => AnnouncementListView(isAdmin: true)),
+    GetPage(name: TEACHER_ANNOUNCEMENTS, page: () => AnnouncementListView(audience: 'teachers')),
+    GetPage(name: PARENT_ANNOUNCEMENTS, page: () => AnnouncementListView(audience: 'parents')),
   ];
 }

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -5,6 +5,7 @@ import '../../data/models/child_model.dart';
 import '../../data/models/parent_model.dart';
 import '../../data/models/school_class_model.dart';
 import '../../data/models/subject_model.dart';
+import '../../data/models/announcement_model.dart';
 import '../../data/models/teacher_model.dart';
 
 class DatabaseService extends GetxService {
@@ -94,5 +95,31 @@ class DatabaseService extends GetxService {
 
   Future<void> deleteChild(String id) async {
     await _firestore.collection('children').doc(id).delete();
+  }
+
+  /// Announcement CRUD operations
+  Future<String> addAnnouncement(AnnouncementModel announcement) async {
+    final doc = await _firestore.collection('announcements').add(announcement.toMap());
+    return doc.id;
+  }
+
+  Future<void> updateAnnouncement(AnnouncementModel announcement) async {
+    await _firestore.collection('announcements').doc(announcement.id).update(announcement.toMap());
+  }
+
+  Future<void> deleteAnnouncement(String id) async {
+    await _firestore.collection('announcements').doc(id).delete();
+  }
+
+  Stream<List<AnnouncementModel>> streamAnnouncements({String? audience}) {
+    Query query = _firestore.collection('announcements');
+    if (audience != null) {
+      query = query.where('audience', arrayContains: audience);
+    }
+    return query
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snapshot) =>
+            snapshot.docs.map((doc) => AnnouncementModel.fromDoc(doc)).toList());
   }
 }

--- a/lib/data/models/announcement_model.dart
+++ b/lib/data/models/announcement_model.dart
@@ -1,0 +1,37 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class AnnouncementModel {
+  final String id;
+  final String title;
+  final String description;
+  final List<String> audience;
+  final DateTime createdAt;
+
+  AnnouncementModel({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.audience,
+    required this.createdAt,
+  });
+
+  factory AnnouncementModel.fromDoc(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>;
+    return AnnouncementModel(
+      id: doc.id,
+      title: data['title'] ?? '',
+      description: data['description'] ?? '',
+      audience: List<String>.from(data['audience'] ?? []),
+      createdAt: (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'description': description,
+      'audience': audience,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+}

--- a/lib/modules/announcement/controllers/announcement_controller.dart
+++ b/lib/modules/announcement/controllers/announcement_controller.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../core/services/database_service.dart';
+import '../../../data/models/announcement_model.dart';
+import '../views/announcement_form_view.dart';
+
+class AnnouncementController extends GetxController {
+  final DatabaseService _db = Get.find();
+
+  final String? audienceFilter;
+
+  AnnouncementController({this.audienceFilter});
+
+  final RxList<AnnouncementModel> announcements = <AnnouncementModel>[].obs;
+
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+  final RxBool teachersSelected = true.obs;
+  final RxBool parentsSelected = true.obs;
+
+  AnnouncementModel? editing;
+  StreamSubscription? _subscription;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _subscription = _db
+        .streamAnnouncements(audience: audienceFilter)
+        .listen((data) {
+      final now = DateTime.now();
+      final valid = <AnnouncementModel>[];
+      for (final ann in data) {
+        if (now.difference(ann.createdAt).inDays >= 7) {
+          deleteAnnouncement(ann.id);
+        } else {
+          valid.add(ann);
+        }
+      }
+      announcements.value = valid;
+    });
+  }
+
+  @override
+  void onClose() {
+    _subscription?.cancel();
+    titleController.dispose();
+    descriptionController.dispose();
+    super.onClose();
+  }
+
+  void openForm({AnnouncementModel? announcement}) {
+    if (announcement != null) {
+      editing = announcement;
+      titleController.text = announcement.title;
+      descriptionController.text = announcement.description;
+      teachersSelected.value = announcement.audience.contains('teachers');
+      parentsSelected.value = announcement.audience.contains('parents');
+    } else {
+      editing = null;
+      clearForm();
+    }
+    Get.to(() => AnnouncementFormView());
+  }
+
+  Future<void> saveAnnouncement() async {
+    final audience = <String>[];
+    if (teachersSelected.value) audience.add('teachers');
+    if (parentsSelected.value) audience.add('parents');
+    final announcement = AnnouncementModel(
+      id: editing?.id ?? '',
+      title: titleController.text,
+      description: descriptionController.text,
+      audience: audience,
+      createdAt: editing?.createdAt ?? DateTime.now(),
+    );
+    if (editing == null) {
+      await _db.addAnnouncement(announcement);
+    } else {
+      await _db.updateAnnouncement(announcement);
+    }
+    Get.back();
+  }
+
+  Future<void> deleteAnnouncement(String id) async {
+    await _db.deleteAnnouncement(id);
+  }
+
+  void clearForm() {
+    titleController.clear();
+    descriptionController.clear();
+    teachersSelected.value = true;
+    parentsSelected.value = true;
+  }
+}

--- a/lib/modules/announcement/views/announcement_detail_view.dart
+++ b/lib/modules/announcement/views/announcement_detail_view.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+import '../../../data/models/announcement_model.dart';
+
+class AnnouncementDetailView extends StatelessWidget {
+  final AnnouncementModel announcement;
+
+  AnnouncementDetailView({required this.announcement});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(announcement.title)),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Text(announcement.description),
+      ),
+    );
+  }
+}

--- a/lib/modules/announcement/views/announcement_form_view.dart
+++ b/lib/modules/announcement/views/announcement_form_view.dart
@@ -1,0 +1,52 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/announcement_controller.dart';
+
+class AnnouncementFormView extends StatelessWidget {
+  AnnouncementFormView({super.key});
+
+  final AnnouncementController controller = Get.find();
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = controller.editing != null;
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(isEditing ? 'Edit Announcement' : 'Add Announcement'),
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: controller.titleController,
+              decoration: const InputDecoration(labelText: 'Title'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: controller.descriptionController,
+              decoration: const InputDecoration(labelText: 'Description'),
+              maxLines: 3,
+            ),
+            Obx(() => CheckboxListTile(
+                  value: controller.teachersSelected.value,
+                  onChanged: (v) => controller.teachersSelected.value = v ?? false,
+                  title: const Text('Teachers'),
+                )),
+            Obx(() => CheckboxListTile(
+                  value: controller.parentsSelected.value,
+                  onChanged: (v) => controller.parentsSelected.value = v ?? false,
+                  title: const Text('Parents'),
+                )),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: controller.saveAnnouncement,
+              child: const Text('Save'),
+            )
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/announcement/views/announcement_list_view.dart
+++ b/lib/modules/announcement/views/announcement_list_view.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/announcement_controller.dart';
+import '../../../data/models/announcement_model.dart';
+import 'announcement_detail_view.dart';
+
+class AnnouncementListView extends StatelessWidget {
+  final bool isAdmin;
+  final String? audience;
+
+  AnnouncementListView({this.isAdmin = false, this.audience});
+
+  @override
+  Widget build(BuildContext context) {
+    final controller =
+        Get.put(AnnouncementController(audienceFilter: audience));
+    return Scaffold(
+      appBar: AppBar(title: const Text('Announcements')),
+      body: Obx(() {
+        if (controller.announcements.isEmpty) {
+          return const Center(child: Text('No announcements'));
+        }
+        return ListView.builder(
+          itemCount: controller.announcements.length,
+          itemBuilder: (context, index) {
+            final ann = controller.announcements[index];
+            return isAdmin
+                ? _buildAdminItem(controller, ann)
+                : _buildItem(ann);
+          },
+        );
+      }),
+      floatingActionButton: isAdmin
+          ? FloatingActionButton(
+              onPressed: () => controller.openForm(),
+              child: const Icon(Icons.add),
+            )
+          : null,
+    );
+  }
+
+  Widget _buildItem(AnnouncementModel ann) {
+    return ListTile(
+      title: Text(ann.title),
+      subtitle: Text(ann.description),
+      onTap: () => Get.to(() => AnnouncementDetailView(announcement: ann)),
+    );
+  }
+
+  Widget _buildAdminItem(
+      AnnouncementController controller, AnnouncementModel ann) {
+    return Dismissible(
+      key: Key(ann.id),
+      background: Container(
+        color: Colors.blue,
+        alignment: Alignment.centerLeft,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: const Icon(Icons.edit, color: Colors.white),
+      ),
+      secondaryBackground: Container(
+        color: Colors.red,
+        alignment: Alignment.centerRight,
+        padding: const EdgeInsets.symmetric(horizontal: 20),
+        child: const Icon(Icons.delete, color: Colors.white),
+      ),
+      confirmDismiss: (direction) async {
+        if (direction == DismissDirection.startToEnd) {
+          controller.openForm(announcement: ann);
+          return false;
+        } else if (direction == DismissDirection.endToStart) {
+          await controller.deleteAnnouncement(ann.id);
+          return true;
+        }
+        return false;
+      },
+      child: _buildItem(ann),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add announcement model and Firestore CRUD helpers
- create announcement controller and views for add, edit, delete, and detail
- wire routes for admin, teacher, and parent announcement lists

## Testing
- `flutter format lib/data/models/announcement_model.dart lib/core/services/database_service.dart lib/modules/announcement/controllers/announcement_controller.dart lib/modules/announcement/views/announcement_list_view.dart lib/modules/announcement/views/announcement_detail_view.dart lib/modules/announcement/views/announcement_form_view.dart lib/app/routes/app_pages.dart` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8054920d883318bb72e35ac872b6d