### PR TITLE
feat: support multiple teachers per class

### DIFF
--- a/lib/data/models/school_class_model.dart
+++ b/lib/data/models/school_class_model.dart
@@ -3,13 +3,13 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 class SchoolClassModel {
   final String id;
   final String name;
-  final String teacherId;
+  final Map<String, String> teacherSubjects; // subjectId -> teacherId
   final List<String> childIds;
 
   SchoolClassModel({
     required this.id,
     required this.name,
-    required this.teacherId,
+    this.teacherSubjects = const {},
     this.childIds = const [],
   });
 
@@ -18,7 +18,8 @@ class SchoolClassModel {
     return SchoolClassModel(
       id: doc.id,
       name: data['name'] ?? '',
-      teacherId: data['teacherId'] ?? '',
+      teacherSubjects:
+          Map<String, String>.from(data['teacherSubjects'] ?? {}),
       childIds: List<String>.from(data['childIds'] ?? []),
     );
   }
@@ -26,7 +27,7 @@ class SchoolClassModel {
   Map<String, dynamic> toMap() {
     return {
       'name': name,
-      'teacherId': teacherId,
+      'teacherSubjects': teacherSubjects,
       'childIds': childIds,
     };
   }


### PR DESCRIPTION
## Summary
- allow storing multiple teachers per class keyed by subject
- enable admin to add, edit, or remove teacher-subject assignments when managing classes
- display class teachers with their subjects

## Testing
- `dart format lib/data/models/school_class_model.dart lib/modules/admin_dashboard/views/admin_control_view.dart` *(failed: command not found)*
- `flutter test` *(failed: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c80a43ff14833197576610837c9811