### PR TITLE
Fix admin children list to display related names

### DIFF
--- a/lib/modules/admin_dashboard/controllers/admin_control_controller.dart
+++ b/lib/modules/admin_dashboard/controllers/admin_control_controller.dart
@@ -8,6 +8,18 @@ import '../../../data/models/school_class_model.dart';
 import '../../../data/models/subject_model.dart';
 import '../../../data/models/teacher_model.dart';
 
+class ChildListItem {
+  final ChildModel child;
+  final String parentName;
+  final String className;
+
+  const ChildListItem({
+    required this.child,
+    required this.parentName,
+    required this.className,
+  });
+}
+
 class AdminControlController extends GetxController {
   final DatabaseService _db = Get.find();
   final AuthService _auth = Get.find();
@@ -16,11 +28,15 @@ class AdminControlController extends GetxController {
   final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
   final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
   final RxList<ChildModel> children = <ChildModel>[].obs;
+  final RxList<ChildListItem> childItems = <ChildListItem>[].obs;
   final RxList<SubjectModel> subjects = <SubjectModel>[].obs;
 
   @override
   void onInit() {
     super.onInit();
+    ever<List<ParentModel>>(parents, (_) => _refreshChildItems());
+    ever<List<SchoolClassModel>>(classes, (_) => _refreshChildItems());
+    ever<List<ChildModel>>(children, (_) => _refreshChildItems());
     _loadAll();
   }
 
@@ -32,6 +48,27 @@ class AdminControlController extends GetxController {
       _loadChildren(),
       _loadSubjects(),
     ]);
+    _refreshChildItems();
+  }
+
+  void _refreshChildItems() {
+    final parentNameById = {for (final p in parents) p.id: p.name};
+    final classNameById = {for (final cl in classes) cl.id: cl.name};
+
+    childItems.assignAll(children.map((child) {
+      final parentName = child.parentId.isEmpty
+          ? 'Unassigned'
+          : parentNameById[child.parentId] ?? 'Unknown parent';
+      final className = child.classId.isEmpty
+          ? 'Unassigned'
+          : classNameById[child.classId] ?? 'Unknown class';
+
+      return ChildListItem(
+        child: child,
+        parentName: parentName,
+        className: className,
+      );
+    }));
   }
 
   Future<void> _loadParents() async {

--- a/lib/modules/admin_dashboard/views/admin_control_view.dart
+++ b/lib/modules/admin_dashboard/views/admin_control_view.dart
@@ -126,40 +126,18 @@ class AdminControlView extends StatelessWidget {
   Widget _buildChildren() {
     return Scaffold(
       body: Obx(() => ListView(
-            children: c.children
-                .map((ch) {
-                  final parentName = ch.parentId.isEmpty
-                      ? 'Unassigned'
-                      : c.parents
-                          .firstWhere(
-                            (p) => p.id == ch.parentId,
-                            orElse: () => ParentModel(
-                              id: '',
-                              name: 'Unknown parent',
-                              email: '',
-                              phone: '',
-                            ),
-                          )
-                          .name;
-                  final className = ch.classId.isEmpty
-                      ? 'Unassigned'
-                      : c.classes
-                          .firstWhere(
-                            (cl) => cl.id == ch.classId,
-                            orElse: () =>
-                                SchoolClassModel(id: '', name: 'Unknown class'),
-                          )
-                          .name;
-                  return ListTile(
-                    title: Text(ch.name),
-                    subtitle: Text('Parent: $parentName | Class: $className'),
-                    trailing: IconButton(
-                      icon: const Icon(Icons.delete),
-                      onPressed: () => c.deleteChild(ch.id),
-                    ),
-                    onTap: () => _showChildDialog(child: ch),
-                  );
-                })
+            children: c.childItems
+                .map((childItem) => ListTile(
+                      title: Text(childItem.child.name),
+                      subtitle: Text(
+                          'Parent: ${childItem.parentName} | Class: ${childItem.className}'),
+                      trailing: IconButton(
+                        icon: const Icon(Icons.delete),
+                        onPressed: () => c.deleteChild(childItem.child.id),
+                      ),
+                      onTap: () =>
+                          _showChildDialog(child: childItem.child),
+                    ))
                 .toList(),
           )),
       floatingActionButton: FloatingActionButton(


### PR DESCRIPTION
## Summary
- introduce a `ChildListItem` view-model in the admin control controller that keeps parent and class names in sync with each child record
- refresh the aggregated list whenever parents, classes, or children change so resolved names are always available
- update the admin children tab to render from the prepared list and show the mapped names instead of raw ids

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9e5231b40833181b9102695770334