### PR TITLE
Fix admin child list to display parent and class names

### DIFF
--- a/lib/modules/admin_dashboard/controllers/admin_control_controller.dart
+++ b/lib/modules/admin_dashboard/controllers/admin_control_controller.dart
@@ -8,18 +8,6 @@ import '../../../data/models/school_class_model.dart';
 import '../../../data/models/subject_model.dart';
 import '../../../data/models/teacher_model.dart';
 
-class ChildListItem {
-  final ChildModel child;
-  final String parentName;
-  final String className;
-
-  const ChildListItem({
-    required this.child,
-    required this.parentName,
-    required this.className,
-  });
-}
-
 class AdminControlController extends GetxController {
   final DatabaseService _db = Get.find();
   final AuthService _auth = Get.find();
@@ -28,15 +16,11 @@ class AdminControlController extends GetxController {
   final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
   final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
   final RxList<ChildModel> children = <ChildModel>[].obs;
-  final RxList<ChildListItem> childItems = <ChildListItem>[].obs;
   final RxList<SubjectModel> subjects = <SubjectModel>[].obs;
 
   @override
   void onInit() {
     super.onInit();
-    ever<List<ParentModel>>(parents, (_) => _refreshChildItems());
-    ever<List<SchoolClassModel>>(classes, (_) => _refreshChildItems());
-    ever<List<ChildModel>>(children, (_) => _refreshChildItems());
     _loadAll();
   }
 
@@ -48,27 +32,6 @@ class AdminControlController extends GetxController {
       _loadChildren(),
       _loadSubjects(),
     ]);
-    _refreshChildItems();
-  }
-
-  void _refreshChildItems() {
-    final parentNameById = {for (final p in parents) p.id: p.name};
-    final classNameById = {for (final cl in classes) cl.id: cl.name};
-
-    childItems.assignAll(children.map((child) {
-      final parentName = child.parentId.isEmpty
-          ? 'Unassigned'
-          : parentNameById[child.parentId] ?? 'Unknown parent';
-      final className = child.classId.isEmpty
-          ? 'Unassigned'
-          : classNameById[child.classId] ?? 'Unknown class';
-
-      return ChildListItem(
-        child: child,
-        parentName: parentName,
-        className: className,
-      );
-    }));
   }
 
   Future<void> _loadParents() async {

--- a/lib/modules/admin_dashboard/views/admin_control_view.dart
+++ b/lib/modules/admin_dashboard/views/admin_control_view.dart
@@ -125,21 +125,34 @@ class AdminControlView extends StatelessWidget {
 
   Widget _buildChildren() {
     return Scaffold(
-      body: Obx(() => ListView(
-            children: c.childItems
-                .map((childItem) => ListTile(
-                      title: Text(childItem.child.name),
-                      subtitle: Text(
-                          'Parent: ${childItem.parentName} | Class: ${childItem.className}'),
-                      trailing: IconButton(
-                        icon: const Icon(Icons.delete),
-                        onPressed: () => c.deleteChild(childItem.child.id),
-                      ),
-                      onTap: () =>
-                          _showChildDialog(child: childItem.child),
-                    ))
-                .toList(),
-          )),
+      body: Obx(() {
+        final parentNameById = {for (final p in c.parents) p.id: p.name};
+        final classNameById = {for (final cl in c.classes) cl.id: cl.name};
+
+        return ListView(
+          children: c.children
+              .map((child) {
+                final parentName = child.parentId.isEmpty
+                    ? 'Unassigned'
+                    : parentNameById[child.parentId] ?? 'Unknown parent';
+                final className = child.classId.isEmpty
+                    ? 'Unassigned'
+                    : classNameById[child.classId] ?? 'Unknown class';
+
+                return ListTile(
+                  title: Text(child.name),
+                  subtitle:
+                      Text('Parent: $parentName | Class: $className'),
+                  trailing: IconButton(
+                    icon: const Icon(Icons.delete),
+                    onPressed: () => c.deleteChild(child.id),
+                  ),
+                  onTap: () => _showChildDialog(child: child),
+                );
+              })
+              .toList(),
+        );
+      }),
       floatingActionButton: FloatingActionButton(
         onPressed: () => _showChildDialog(),
         child: const Icon(Icons.add),


### PR DESCRIPTION
## Summary
- simplify the admin controller by removing the cached child list
- derive parent and class display names inline when building the children list so the UI shows human-readable values

## Testing
- flutter test *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9e81236a083318c3c45a5707d3764