### PR TITLE
Refresh announcement and admin control UI

### DIFF
--- a/lib/modules/announcement/views/announcement_detail_view.dart
+++ b/lib/modules/announcement/views/announcement_detail_view.dart
@@ -1,20 +1,181 @@
 import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
 
 import '../../../data/models/announcement_model.dart';
 
 class AnnouncementDetailView extends StatelessWidget {
   final AnnouncementModel announcement;
 
-  AnnouncementDetailView({required this.announcement});
+  AnnouncementDetailView({super.key, required this.announcement});
+
+  final DateFormat _dateFormat = DateFormat('EEEE, MMM d, yyyy • h:mm a');
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateText = _dateFormat.format(announcement.createdAt);
+    final audienceLabels = _audienceLabels();
+
     return Scaffold(
-      appBar: AppBar(title: Text(announcement.title)),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Text(announcement.description),
+      appBar: AppBar(
+        title: const Text('Announcement'),
+        centerTitle: true,
       ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              theme.colorScheme.primary.withOpacity(0.06),
+              theme.colorScheme.surface,
+            ],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 720),
+              child: Card(
+                elevation: 12,
+                shadowColor: theme.colorScheme.primary.withOpacity(0.2),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(28),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(28),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.all(16),
+                            decoration: BoxDecoration(
+                              color:
+                                  theme.colorScheme.primary.withOpacity(0.12),
+                              borderRadius: BorderRadius.circular(18),
+                            ),
+                            child: Icon(
+                              Icons.campaign_rounded,
+                              size: 28,
+                              color: theme.colorScheme.primary,
+                            ),
+                          ),
+                          const SizedBox(width: 16),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  announcement.title,
+                                  style:
+                                      theme.textTheme.headlineSmall?.copyWith(
+                                    fontWeight: FontWeight.w700,
+                                  ),
+                                ),
+                                const SizedBox(height: 8),
+                                Text(
+                                  dateText,
+                                  style:
+                                      theme.textTheme.bodyMedium?.copyWith(
+                                    color: theme.colorScheme.primary,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                      const SizedBox(height: 24),
+                      if (audienceLabels.isNotEmpty) ...[
+                        Text(
+                          'Audience',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Wrap(
+                          spacing: 10,
+                          runSpacing: 10,
+                          children: audienceLabels
+                              .map(
+                                (label) => _buildTagChip(
+                                  context,
+                                  icon: Icons.people_outline,
+                                  label: label,
+                                ),
+                              )
+                              .toList(),
+                        ),
+                        const SizedBox(height: 24),
+                      ],
+                      Divider(color: theme.colorScheme.surfaceVariant),
+                      const SizedBox(height: 24),
+                      Text(
+                        announcement.description,
+                        style: theme.textTheme.bodyLarge?.copyWith(
+                          height: 1.6,
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<String> _audienceLabels() {
+    if (announcement.audience.isEmpty) {
+      return ['All audiences'];
+    }
+    final seen = <String>{};
+    final labels = <String>[];
+    for (final item in announcement.audience) {
+      final formatted = _capitalize(item.trim());
+      if (formatted.isEmpty) continue;
+      final key = formatted.toLowerCase();
+      if (seen.add(key)) {
+        labels.add(formatted);
+      }
+    }
+    return labels;
+  }
+
+  String _capitalize(String value) {
+    if (value.isEmpty) return value;
+    return value[0].toUpperCase() + value.substring(1);
+  }
+
+  Widget _buildTagChip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+  }) {
+    final theme = Theme.of(context);
+    return Chip(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      avatar: Icon(
+        icon,
+        size: 18,
+        color: theme.colorScheme.primary,
+      ),
+      label: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     );
   }
 }

--- a/lib/modules/announcement/views/announcement_list_view.dart
+++ b/lib/modules/announcement/views/announcement_list_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
 
 import '../controllers/announcement_controller.dart';
 import '../../../data/models/announcement_model.dart';
@@ -9,60 +10,221 @@ class AnnouncementListView extends StatelessWidget {
   final bool isAdmin;
   final String? audience;
 
-  AnnouncementListView({this.isAdmin = false, this.audience});
+  AnnouncementListView({super.key, this.isAdmin = false, this.audience});
+
+  static final DateFormat _dateFormat = DateFormat('MMM d, yyyy • h:mm a');
 
   @override
   Widget build(BuildContext context) {
     final controller =
         Get.put(AnnouncementController(audienceFilter: audience));
+    final theme = Theme.of(context);
     return Scaffold(
-      appBar: AppBar(title: const Text('Announcements')),
-      body: Obx(() {
-        if (controller.announcements.isEmpty) {
-          return const Center(child: Text('No announcements'));
-        }
-        return ListView.builder(
-          itemCount: controller.announcements.length,
-          itemBuilder: (context, index) {
-            final ann = controller.announcements[index];
-            return isAdmin
-                ? _buildAdminItem(controller, ann)
-                : _buildItem(ann);
-          },
-        );
-      }),
+      backgroundColor: theme.colorScheme.surface,
+      appBar: AppBar(
+        title: const Text('Announcements'),
+        centerTitle: true,
+      ),
+      body: Container(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              theme.colorScheme.primary.withOpacity(0.06),
+              theme.colorScheme.surface,
+            ],
+            begin: Alignment.topCenter,
+            end: Alignment.bottomCenter,
+          ),
+        ),
+        child: Obx(() {
+          if (controller.announcements.isEmpty) {
+            return _buildEmptyState(context);
+          }
+          return ListView.separated(
+            padding: EdgeInsets.fromLTRB(16, 24, 16, isAdmin ? 120 : 32),
+            physics: const BouncingScrollPhysics(),
+            itemCount: controller.announcements.length,
+            separatorBuilder: (_, __) => const SizedBox(height: 18),
+            itemBuilder: (context, index) {
+              final ann = controller.announcements[index];
+              return isAdmin
+                  ? _buildAdminItem(context, controller, ann)
+                  : _buildAnnouncementCard(context, ann);
+            },
+          );
+        }),
+      ),
       floatingActionButton: isAdmin
-          ? FloatingActionButton(
+          ? FloatingActionButton.extended(
+              heroTag: 'announcementFab',
               onPressed: () => controller.openForm(),
-              child: const Icon(Icons.add),
+              icon: const Icon(Icons.add),
+              label: const Text('New Announcement'),
             )
           : null,
     );
   }
 
-  Widget _buildItem(AnnouncementModel ann) {
-    return ListTile(
-      title: Text(ann.title),
-      subtitle: Text(ann.description),
-      onTap: () => Get.to(() => AnnouncementDetailView(announcement: ann)),
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              height: 88,
+              width: 88,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.campaign_outlined,
+                color: theme.colorScheme.primary,
+                size: 40,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No announcements yet',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Stay tuned! New announcements will appear here.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
     );
   }
 
-  Widget _buildAdminItem(
+  Widget _buildAnnouncementCard(BuildContext context, AnnouncementModel ann,
+      {List<Widget> footer = const []}) {
+    final theme = Theme.of(context);
+    final dateText = _dateFormat.format(ann.createdAt);
+    final audienceLabels = _audienceLabels(ann);
+
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => Get.to(() => AnnouncementDetailView(announcement: ann)),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: theme.colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.08),
+                blurRadius: 18,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Container(
+                      padding: const EdgeInsets.all(12),
+                      decoration: BoxDecoration(
+                        color: theme.colorScheme.primary.withOpacity(0.12),
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Icon(
+                        Icons.campaign_outlined,
+                        color: theme.colorScheme.primary,
+                      ),
+                    ),
+                    const SizedBox(width: 12),
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            ann.title,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            dateText,
+                            style: theme.textTheme.bodySmall?.copyWith(
+                              color: theme.colorScheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  ann.description,
+                  maxLines: 3,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    height: 1.5,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                Wrap(
+                  spacing: 10,
+                  runSpacing: 8,
+                  children: audienceLabels
+                      .map((label) => _buildTagChip(
+                            context,
+                            Icons.people_outline,
+                            label,
+                          ))
+                      .toList(),
+                ),
+                if (footer.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  ...footer,
+                ],
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildAdminItem(BuildContext context,
       AnnouncementController controller, AnnouncementModel ann) {
+    final theme = Theme.of(context);
     return Dismissible(
       key: Key(ann.id),
-      background: Container(
-        color: Colors.blue,
+      background: _buildSwipeBackground(
+        context,
         alignment: Alignment.centerLeft,
-        padding: const EdgeInsets.symmetric(horizontal: 20),
-        child: const Icon(Icons.edit, color: Colors.white),
+        color: theme.colorScheme.primary,
+        icon: Icons.edit_outlined,
+        label: 'Edit',
       ),
-      secondaryBackground: Container(
-        color: Colors.red,
+      secondaryBackground: _buildSwipeBackground(
+        context,
         alignment: Alignment.centerRight,
-        padding: const EdgeInsets.symmetric(horizontal: 20),
-        child: const Icon(Icons.delete, color: Colors.white),
+        color: theme.colorScheme.error,
+        icon: Icons.delete_outline,
+        label: 'Delete',
       ),
       confirmDismiss: (direction) async {
         if (direction == DismissDirection.startToEnd) {
@@ -74,7 +236,112 @@ class AnnouncementListView extends StatelessWidget {
         }
         return false;
       },
-      child: _buildItem(ann),
+      child: _buildAnnouncementCard(
+        context,
+        ann,
+        footer: [
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.swipe,
+                size: 16,
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                'Swipe for quick actions',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontStyle: FontStyle.italic,
+                ),
+              ),
+            ],
+          ),
+        ],
+      ),
     );
+  }
+
+  Widget _buildSwipeBackground(
+    BuildContext context, {
+    required Alignment alignment,
+    required Color color,
+    required IconData icon,
+    required String label,
+  }) {
+    return Container(
+      margin: const EdgeInsets.symmetric(horizontal: 4),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(20),
+        gradient: LinearGradient(
+          colors: [color.withOpacity(0.85), color],
+          begin: alignment == Alignment.centerLeft
+              ? Alignment.centerLeft
+              : Alignment.centerRight,
+          end: alignment == Alignment.centerLeft
+              ? Alignment.centerRight
+              : Alignment.centerLeft,
+        ),
+      ),
+      alignment: alignment,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, color: Colors.white),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                  color: Colors.white,
+                  fontWeight: FontWeight.w600,
+                ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTagChip(BuildContext context, IconData icon, String label) {
+    final theme = Theme.of(context);
+    return Chip(
+      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 4),
+      avatar: Icon(
+        icon,
+        size: 18,
+        color: theme.colorScheme.primary,
+      ),
+      label: Text(
+        label,
+        style: theme.textTheme.bodySmall?.copyWith(
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+    );
+  }
+
+  List<String> _audienceLabels(AnnouncementModel ann) {
+    if (ann.audience.isEmpty) {
+      return ['All audiences'];
+    }
+    final seen = <String>{};
+    final labels = <String>[];
+    for (final item in ann.audience) {
+      final formatted = _capitalize(item.trim());
+      if (formatted.isEmpty) continue;
+      final key = formatted.toLowerCase();
+      if (seen.add(key)) {
+        labels.add(formatted);
+      }
+    }
+    return labels;
+  }
+
+  String _capitalize(String value) {
+    if (value.isEmpty) return value;
+    return value[0].toUpperCase() + value.substring(1);
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   url_launcher: ^6.3.2
   flutter_dotenv: ^5.2.1
   animated_splash_screen: ^1.3.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- redesign announcement list with cards, gradient styling, and audience chips
- update announcement detail view to highlight metadata and readable timestamps
- restyle admin control tabs with modern cards, contextual chips, and empty states
- add intl dependency to format announcement dates

## Testing
- not run (Flutter SDK unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68c9ec0ce54083319a243fa968883c61