### PR TITLE
Add courses module with role-specific UI and PDF export

### DIFF
--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -8,6 +8,9 @@ import '../../modules/admin_dashboard/views/admin_dashboard_view.dart';
 import '../../modules/teachers_dashboard/views/teacher_dashboard_view.dart';
 import '../../modules/parents_dashboard/views/parent_dashboard_view.dart';
 import '../../modules/admin_dashboard/views/admin_control_view.dart';
+import '../../modules/courses/views/admin_courses_view.dart';
+import '../../modules/courses/views/teacher_courses_view.dart';
+import '../../modules/courses/views/parent_courses_view.dart';
 
 abstract class AppPages {
   static const SPLASH     = '/splash';
@@ -16,6 +19,9 @@ abstract class AppPages {
   static const ADMIN_CONTROL = '/admin/control';
   static const TEACHER_HOME = '/teacher';
   static const PARENT_HOME  = '/parent';
+  static const ADMIN_COURSES = '/admin/courses';
+  static const TEACHER_COURSES = '/teacher/courses';
+  static const PARENT_COURSES = '/parent/courses';
   static const ADMIN_ANNOUNCEMENTS = '/admin/announcements';
   static const TEACHER_ANNOUNCEMENTS = '/teacher/announcements';
   static const PARENT_ANNOUNCEMENTS = '/parent/announcements';
@@ -27,6 +33,9 @@ abstract class AppPages {
     GetPage(name: ADMIN_CONTROL, page: () => AdminControlView()),
     GetPage(name: TEACHER_HOME,page: () => TeacherDashboard()),
     GetPage(name: PARENT_HOME, page: () => ParentDashboard()),
+    GetPage(name: ADMIN_COURSES, page: () => AdminCoursesView()),
+    GetPage(name: TEACHER_COURSES, page: () => TeacherCoursesView()),
+    GetPage(name: PARENT_COURSES, page: () => ParentCoursesView()),
     GetPage(name: ADMIN_ANNOUNCEMENTS, page: () => AnnouncementListView(isAdmin: true)),
     GetPage(name: TEACHER_ANNOUNCEMENTS, page: () => AnnouncementListView(audience: 'teachers')),
     GetPage(name: PARENT_ANNOUNCEMENTS, page: () => AnnouncementListView(audience: 'parents')),

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -7,6 +7,7 @@ import '../../data/models/school_class_model.dart';
 import '../../data/models/subject_model.dart';
 import '../../data/models/announcement_model.dart';
 import '../../data/models/teacher_model.dart';
+import '../../data/models/course_model.dart';
 
 class DatabaseService extends GetxService {
   final FirebaseFirestore _firestore = FirebaseFirestore.instance;
@@ -121,5 +122,28 @@ class DatabaseService extends GetxService {
         .snapshots()
         .map((snapshot) =>
             snapshot.docs.map((doc) => AnnouncementModel.fromDoc(doc)).toList());
+  }
+
+  /// Course CRUD operations
+  Future<String> addCourse(CourseModel course) async {
+    final doc = await _firestore.collection('courses').add(course.toMap());
+    return doc.id;
+  }
+
+  Future<void> updateCourse(CourseModel course) async {
+    await _firestore.collection('courses').doc(course.id).update(course.toMap());
+  }
+
+  Future<void> deleteCourse(String id) async {
+    await _firestore.collection('courses').doc(id).delete();
+  }
+
+  Stream<List<CourseModel>> streamCourses() {
+    return _firestore
+        .collection('courses')
+        .orderBy('createdAt', descending: true)
+        .snapshots()
+        .map((snapshot) =>
+            snapshot.docs.map((doc) => CourseModel.fromDoc(doc)).toList());
   }
 }

--- a/lib/data/models/course_model.dart
+++ b/lib/data/models/course_model.dart
@@ -1,0 +1,62 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+
+class CourseModel {
+  final String id;
+  final String title;
+  final String description;
+  final String content;
+  final String subjectId;
+  final String subjectName;
+  final String teacherId;
+  final String teacherName;
+  final List<String> classIds;
+  final List<String> classNames;
+  final DateTime createdAt;
+
+  CourseModel({
+    required this.id,
+    required this.title,
+    required this.description,
+    required this.content,
+    required this.subjectId,
+    required this.subjectName,
+    required this.teacherId,
+    required this.teacherName,
+    required this.classIds,
+    required this.classNames,
+    required this.createdAt,
+  });
+
+  factory CourseModel.fromDoc(DocumentSnapshot doc) {
+    final data = doc.data() as Map<String, dynamic>? ?? {};
+    return CourseModel(
+      id: doc.id,
+      title: data['title'] ?? '',
+      description: data['description'] ?? '',
+      content: data['content'] ?? '',
+      subjectId: data['subjectId'] ?? '',
+      subjectName: data['subjectName'] ?? '',
+      teacherId: data['teacherId'] ?? '',
+      teacherName: data['teacherName'] ?? '',
+      classIds: List<String>.from(data['classIds'] ?? const []),
+      classNames: List<String>.from(data['classNames'] ?? const []),
+      createdAt:
+          (data['createdAt'] as Timestamp?)?.toDate() ?? DateTime.now(),
+    );
+  }
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'description': description,
+      'content': content,
+      'subjectId': subjectId,
+      'subjectName': subjectName,
+      'teacherId': teacherId,
+      'teacherName': teacherName,
+      'classIds': classIds,
+      'classNames': classNames,
+      'createdAt': Timestamp.fromDate(createdAt),
+    };
+  }
+}

--- a/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
+++ b/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
@@ -34,7 +34,7 @@ class AdminDashboard extends StatelessWidget {
           title: 'Courses',
           subtitle: 'Manage curriculum',
           color: Colors.blue,
-          onTap: () => Get.toNamed('/admin/courses'),
+          onTap: () => Get.toNamed(AppPages.ADMIN_COURSES),
         ),
         DashboardCard(
           icon: Icons.assignment,

--- a/lib/modules/courses/controllers/admin_courses_controller.dart
+++ b/lib/modules/courses/controllers/admin_courses_controller.dart
@@ -1,0 +1,144 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:get/get.dart';
+
+import '../../../core/services/database_service.dart';
+import '../../../data/models/course_model.dart';
+import '../../../data/models/school_class_model.dart';
+import '../../../data/models/subject_model.dart';
+import '../../../data/models/teacher_model.dart';
+
+class AdminCoursesController extends GetxController {
+  final DatabaseService _db = Get.find();
+
+  final RxBool isLoading = true.obs;
+
+  final RxList<CourseModel> _allCourses = <CourseModel>[].obs;
+  final RxList<CourseModel> courses = <CourseModel>[].obs;
+
+  final RxList<SubjectModel> subjects = <SubjectModel>[].obs;
+  final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
+  final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
+
+  final RxString selectedSubjectId = ''.obs;
+  final RxString selectedTeacherId = ''.obs;
+  final RxString selectedClassId = ''.obs;
+
+  StreamSubscription<List<CourseModel>>? _subscription;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    try {
+      isLoading.value = true;
+      await Future.wait([
+        _loadSubjects(),
+        _loadTeachers(),
+        _loadClasses(),
+      ]);
+
+      _subscription = _db.streamCourses().listen((data) {
+        _allCourses.assignAll(data);
+        _applyFilters();
+      });
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to load courses. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> _loadSubjects() async {
+    final snap = await _db.firestore.collection('subjects').get();
+    final data = snap.docs.map((doc) => SubjectModel.fromDoc(doc)).toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    subjects.assignAll(data);
+  }
+
+  Future<void> _loadTeachers() async {
+    final snap = await _db.firestore.collection('teachers').get();
+    final data = snap.docs.map((doc) => TeacherModel.fromDoc(doc)).toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    teachers.assignAll(data);
+  }
+
+  Future<void> _loadClasses() async {
+    final snap = await _db.firestore.collection('classes').get();
+    final data = snap.docs.map((doc) => SchoolClassModel.fromDoc(doc)).toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+    classes.assignAll(data);
+  }
+
+  void updateSubjectFilter(String value) {
+    selectedSubjectId.value = value;
+    _applyFilters();
+  }
+
+  void updateTeacherFilter(String value) {
+    selectedTeacherId.value = value;
+    _applyFilters();
+  }
+
+  void updateClassFilter(String value) {
+    selectedClassId.value = value;
+    _applyFilters();
+  }
+
+  void clearFilters() {
+    selectedSubjectId.value = '';
+    selectedTeacherId.value = '';
+    selectedClassId.value = '';
+    _applyFilters();
+  }
+
+  void _applyFilters() {
+    Iterable<CourseModel> filtered = _allCourses;
+    if (selectedSubjectId.value.isNotEmpty) {
+      filtered =
+          filtered.where((course) => course.subjectId == selectedSubjectId.value);
+    }
+    if (selectedTeacherId.value.isNotEmpty) {
+      filtered = filtered
+          .where((course) => course.teacherId == selectedTeacherId.value);
+    }
+    if (selectedClassId.value.isNotEmpty) {
+      filtered = filtered
+          .where((course) => course.classIds.contains(selectedClassId.value));
+    }
+
+    final list = filtered.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    courses.assignAll(list);
+  }
+
+  String subjectName(String id) {
+    return subjects.firstWhereOrNull((subject) => subject.id == id)?.name ??
+        'Unknown Subject';
+  }
+
+  String teacherName(String id) {
+    return teachers.firstWhereOrNull((teacher) => teacher.id == id)?.name ??
+        'Unknown Teacher';
+  }
+
+  String className(String id) {
+    return classes.firstWhereOrNull((schoolClass) => schoolClass.id == id)
+            ?.name ??
+        'Class';
+  }
+
+  @override
+  void onClose() {
+    _subscription?.cancel();
+    super.onClose();
+  }
+}

--- a/lib/modules/courses/controllers/parent_courses_controller.dart
+++ b/lib/modules/courses/controllers/parent_courses_controller.dart
@@ -1,0 +1,165 @@
+import 'dart:async';
+
+import 'package:collection/collection.dart';
+import 'package:get/get.dart';
+
+import '../../../core/services/auth_service.dart';
+import '../../../core/services/database_service.dart';
+import '../../../data/models/child_model.dart';
+import '../../../data/models/course_model.dart';
+import '../../../data/models/school_class_model.dart';
+
+class ParentCoursesController extends GetxController {
+  final DatabaseService _db = Get.find();
+  final AuthService _auth = Get.find();
+
+  final RxBool isLoading = true.obs;
+
+  final RxList<CourseModel> _allCourses = <CourseModel>[].obs;
+  final RxList<CourseModel> courses = <CourseModel>[].obs;
+  final RxList<ChildModel> children = <ChildModel>[].obs;
+  final RxMap<String, SchoolClassModel> classesById =
+      <String, SchoolClassModel>{}.obs;
+
+  final RxString selectedChildId = ''.obs;
+  final RxString selectedSubjectId = ''.obs;
+
+  final RxList<SubjectFilterOption> subjectOptions =
+      <SubjectFilterOption>[].obs;
+
+  StreamSubscription<List<CourseModel>>? _subscription;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    try {
+      isLoading.value = true;
+      final uid = _auth.currentUser?.uid;
+      if (uid == null) {
+        Get.snackbar(
+          'Error',
+          'Unable to determine the authenticated parent.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        return;
+      }
+
+      await _loadChildren(uid);
+
+      _subscription = _db.streamCourses().listen((data) {
+        _allCourses.assignAll(data);
+        _buildSubjectOptions();
+        _applyFilters();
+      });
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to load courses. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> _loadChildren(String parentId) async {
+    final childrenSnap = await _db.firestore
+        .collection('children')
+        .where('parentId', isEqualTo: parentId)
+        .get();
+    final loadedChildren =
+        childrenSnap.docs.map((doc) => ChildModel.fromDoc(doc)).toList();
+    children.assignAll(loadedChildren);
+
+    final classesSnap = await _db.firestore.collection('classes').get();
+    final classesMap = {
+      for (final doc in classesSnap.docs)
+        doc.id: SchoolClassModel.fromDoc(doc)
+    };
+    classesById.assignAll(classesMap);
+  }
+
+  void updateChildFilter(String childId) {
+    selectedChildId.value = childId;
+    _applyFilters();
+  }
+
+  void updateSubjectFilter(String subjectId) {
+    selectedSubjectId.value = subjectId;
+    _applyFilters();
+  }
+
+  void _applyFilters() {
+    final relevantClassIds = _parentClassIds;
+    Iterable<CourseModel> filtered = _allCourses.where(
+        (course) => course.classIds.any(relevantClassIds.contains));
+
+    if (selectedChildId.value.isNotEmpty) {
+      final child =
+          children.firstWhereOrNull((c) => c.id == selectedChildId.value);
+      if (child != null && child.classId.isNotEmpty) {
+        filtered = filtered
+            .where((course) => course.classIds.contains(child.classId));
+      }
+    }
+
+    if (selectedSubjectId.value.isNotEmpty) {
+      filtered = filtered
+          .where((course) => course.subjectId == selectedSubjectId.value);
+    }
+
+    final list = filtered.toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+    courses.assignAll(list);
+  }
+
+  void _buildSubjectOptions() {
+    final relevantClassIds = _parentClassIds;
+    final subjects = <String, String>{};
+    for (final course in _allCourses) {
+      if (!course.classIds.any(relevantClassIds.contains)) {
+        continue;
+      }
+      if (course.subjectId.isEmpty) {
+        continue;
+      }
+      subjects[course.subjectId] = course.subjectName;
+    }
+    final list = subjects.entries
+        .map((entry) => SubjectFilterOption(
+              id: entry.key,
+              name: entry.value,
+            ))
+        .toList()
+      ..sort((a, b) => a.name.compareTo(b.name));
+
+    subjectOptions.assignAll(list);
+    if (list.every((element) => element.id != selectedSubjectId.value)) {
+      selectedSubjectId.value = '';
+    }
+  }
+
+  Set<String> get _parentClassIds => children
+      .map((child) => child.classId)
+      .where((id) => id.isNotEmpty)
+      .toSet();
+
+  SchoolClassModel? classForId(String id) => classesById[id];
+
+  @override
+  void onClose() {
+    _subscription?.cancel();
+    super.onClose();
+  }
+}
+
+class SubjectFilterOption {
+  final String id;
+  final String name;
+
+  SubjectFilterOption({required this.id, required this.name});
+}

--- a/lib/modules/courses/controllers/teacher_courses_controller.dart
+++ b/lib/modules/courses/controllers/teacher_courses_controller.dart
@@ -1,0 +1,238 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../core/services/auth_service.dart';
+import '../../../core/services/database_service.dart';
+import '../../../data/models/course_model.dart';
+import '../../../data/models/school_class_model.dart';
+import '../../../data/models/subject_model.dart';
+import '../../../data/models/teacher_model.dart';
+import '../views/course_form_view.dart';
+
+class TeacherCoursesController extends GetxController {
+  final DatabaseService _db = Get.find();
+  final AuthService _auth = Get.find();
+
+  final RxBool isLoading = true.obs;
+  final RxBool isSaving = false.obs;
+
+  final RxList<CourseModel> courses = <CourseModel>[].obs;
+  final RxList<SchoolClassModel> availableClasses = <SchoolClassModel>[].obs;
+  final RxSet<String> selectedClassIds = <String>{}.obs;
+
+  final GlobalKey<FormState> formKey = GlobalKey<FormState>();
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+  final TextEditingController contentController = TextEditingController();
+
+  final Rxn<TeacherModel> teacher = Rxn<TeacherModel>();
+  final Rxn<SubjectModel> subject = Rxn<SubjectModel>();
+
+  CourseModel? editing;
+  StreamSubscription<List<CourseModel>>? _subscription;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _initialize();
+  }
+
+  Future<void> _initialize() async {
+    try {
+      isLoading.value = true;
+      final uid = _auth.currentUser?.uid;
+      if (uid == null) {
+        Get.snackbar(
+          'Error',
+          'Unable to determine the authenticated teacher.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        return;
+      }
+
+      final teacherDoc =
+          await _db.firestore.collection('teachers').doc(uid).get();
+      if (!teacherDoc.exists) {
+        Get.snackbar(
+          'Profile missing',
+          'Please contact the administrator to complete your profile.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        return;
+      }
+
+      final teacherModel = TeacherModel.fromDoc(teacherDoc);
+      teacher.value = teacherModel;
+
+      if (teacherModel.subjectId.isNotEmpty) {
+        final subjectDoc = await _db.firestore
+            .collection('subjects')
+            .doc(teacherModel.subjectId)
+            .get();
+        if (subjectDoc.exists) {
+          subject.value = SubjectModel.fromDoc(subjectDoc);
+        }
+      }
+
+      final classesSnap = await _db.firestore.collection('classes').get();
+      final classes = classesSnap.docs
+          .map((doc) => SchoolClassModel.fromDoc(doc))
+          .where((schoolClass) =>
+              schoolClass.teacherSubjects[teacherModel.subjectId] ==
+              teacherModel.id)
+          .toList()
+        ..sort((a, b) => a.name.compareTo(b.name));
+      availableClasses.assignAll(classes);
+
+      _subscription = _db.streamCourses().listen((data) {
+        final filtered = data
+            .where((course) => course.teacherId == teacherModel.id)
+            .toList()
+          ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        courses.assignAll(filtered);
+      });
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to load your courses. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  void openForm({CourseModel? course}) {
+    if (course != null) {
+      editing = course;
+      titleController.text = course.title;
+      descriptionController.text = course.description;
+      contentController.text = course.content;
+      selectedClassIds
+        ..clear()
+        ..addAll(course.classIds);
+    } else {
+      editing = null;
+      clearForm();
+    }
+    Get.to(() => CourseFormView(controller: this));
+  }
+
+  Future<void> saveCourse() async {
+    if (formKey.currentState?.validate() != true) {
+      return;
+    }
+    if (selectedClassIds.isEmpty) {
+      Get.snackbar(
+        'Missing information',
+        'Please select at least one class.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+    final teacherModel = teacher.value;
+    if (teacherModel == null) {
+      Get.snackbar(
+        'Error',
+        'Teacher profile missing. Please contact the administrator.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+
+    final selectedClasses = availableClasses
+        .where((element) => selectedClassIds.contains(element.id))
+        .toList();
+    final subjectName = subject.value?.name.trim().isNotEmpty == true
+        ? subject.value!.name
+        : 'Unknown Subject';
+
+    final course = CourseModel(
+      id: editing?.id ?? '',
+      title: titleController.text.trim(),
+      description: descriptionController.text.trim(),
+      content: contentController.text.trim(),
+      subjectId: subject.value?.id ?? teacherModel.subjectId,
+      subjectName: subjectName,
+      teacherId: teacherModel.id,
+      teacherName: teacherModel.name,
+      classIds: selectedClasses.map((e) => e.id).toList(),
+      classNames: selectedClasses.map((e) => e.name).toList(),
+      createdAt: editing?.createdAt ?? DateTime.now(),
+    );
+
+    try {
+      isSaving.value = true;
+      if (editing == null) {
+        await _db.addCourse(course);
+        Get.snackbar(
+          'Course added',
+          'Your course has been published successfully.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+      } else {
+        await _db.updateCourse(course);
+        Get.snackbar(
+          'Course updated',
+          'Your changes have been saved.',
+          snackPosition: SnackPosition.BOTTOM,
+        );
+      }
+      Get.back();
+      clearForm();
+      editing = null;
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to save the course. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  Future<void> deleteCourse(String id) async {
+    try {
+      await _db.deleteCourse(id);
+      Get.snackbar(
+        'Course removed',
+        'The course has been deleted.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to delete the course. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+
+  void toggleClassSelection(String classId) {
+    if (selectedClassIds.contains(classId)) {
+      selectedClassIds.remove(classId);
+    } else {
+      selectedClassIds.add(classId);
+    }
+    selectedClassIds.refresh();
+  }
+
+  void clearForm() {
+    titleController.clear();
+    descriptionController.clear();
+    contentController.clear();
+    selectedClassIds.clear();
+  }
+
+  @override
+  void onClose() {
+    _subscription?.cancel();
+    titleController.dispose();
+    descriptionController.dispose();
+    contentController.dispose();
+    super.onClose();
+  }
+}

--- a/lib/modules/courses/views/admin_courses_view.dart
+++ b/lib/modules/courses/views/admin_courses_view.dart
@@ -1,0 +1,314 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../data/models/course_model.dart';
+import '../controllers/admin_courses_controller.dart';
+import 'course_detail_view.dart';
+
+class AdminCoursesView extends StatelessWidget {
+  final AdminCoursesController controller = Get.put(AdminCoursesController());
+
+  AdminCoursesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Courses'),
+        centerTitle: true,
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        return Column(
+          children: [
+            _buildFilters(context),
+            Expanded(
+              child: Obx(() {
+                if (controller.courses.isEmpty) {
+                  return _buildEmptyState(context);
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                  itemCount: controller.courses.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final course = controller.courses[index];
+                    return _AdminCourseTile(course: course);
+                  },
+                );
+              }),
+            ),
+          ],
+        );
+      }),
+    );
+  }
+
+  Widget _buildFilters(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Text(
+                'Filter courses',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              Obx(() {
+                final hasFilters = controller.selectedSubjectId.value.isNotEmpty ||
+                    controller.selectedTeacherId.value.isNotEmpty ||
+                    controller.selectedClassId.value.isNotEmpty;
+                return TextButton.icon(
+                  onPressed: hasFilters ? controller.clearFilters : null,
+                  icon: const Icon(Icons.filter_alt_off_outlined, size: 18),
+                  label: const Text('Clear'),
+                );
+              }),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: Obx(() {
+                  return DropdownButtonFormField<String>(
+                    value: controller.selectedSubjectId.value.isEmpty
+                        ? null
+                        : controller.selectedSubjectId.value,
+                    decoration: const InputDecoration(
+                      labelText: 'Subject',
+                      border: OutlineInputBorder(),
+                    ),
+                    hint: const Text('All subjects'),
+                    items: [
+                      const DropdownMenuItem<String>(
+                        value: '',
+                        child: Text('All subjects'),
+                      ),
+                      ...controller.subjects
+                          .map(
+                            (subject) => DropdownMenuItem<String>(
+                              value: subject.id,
+                              child: Text(subject.name),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) =>
+                        controller.updateSubjectFilter(value ?? ''),
+                  );
+                }),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Obx(() {
+                  return DropdownButtonFormField<String>(
+                    value: controller.selectedTeacherId.value.isEmpty
+                        ? null
+                        : controller.selectedTeacherId.value,
+                    decoration: const InputDecoration(
+                      labelText: 'Teacher',
+                      border: OutlineInputBorder(),
+                    ),
+                    hint: const Text('All teachers'),
+                    items: [
+                      const DropdownMenuItem<String>(
+                        value: '',
+                        child: Text('All teachers'),
+                      ),
+                      ...controller.teachers
+                          .map(
+                            (teacher) => DropdownMenuItem<String>(
+                              value: teacher.id,
+                              child: Text(teacher.name),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) =>
+                        controller.updateTeacherFilter(value ?? ''),
+                  );
+                }),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: Obx(() {
+                  return DropdownButtonFormField<String>(
+                    value: controller.selectedClassId.value.isEmpty
+                        ? null
+                        : controller.selectedClassId.value,
+                    decoration: const InputDecoration(
+                      labelText: 'Class',
+                      border: OutlineInputBorder(),
+                    ),
+                    hint: const Text('All classes'),
+                    items: [
+                      const DropdownMenuItem<String>(
+                        value: '',
+                        child: Text('All classes'),
+                      ),
+                      ...controller.classes
+                          .map(
+                            (schoolClass) => DropdownMenuItem<String>(
+                              value: schoolClass.id,
+                              child: Text(schoolClass.name),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) =>
+                        controller.updateClassFilter(value ?? ''),
+                  );
+                }),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.menu_book_outlined,
+                color: theme.colorScheme.primary,
+                size: 40,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No courses found',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Adjust the filters or check back later for new courses.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AdminCourseTile extends StatelessWidget {
+  final CourseModel course;
+
+  const _AdminCourseTile({required this.course});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subject = course.subjectName.isNotEmpty
+        ? course.subjectName
+        : 'Subject not specified';
+    final teacher = course.teacherName.isNotEmpty
+        ? course.teacherName
+        : 'Teacher unknown';
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => Get.to(() => CourseDetailView(course: course)),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: theme.colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.08),
+                blurRadius: 18,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  course.title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.person_outline,
+                      size: 18,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        teacher,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.menu_book_outlined,
+                      size: 18,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        subject,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/courses/views/course_detail_view.dart
+++ b/lib/modules/courses/views/course_detail_view.dart
@@ -1,0 +1,271 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
+
+import '../../../data/models/course_model.dart';
+
+class CourseDetailView extends StatelessWidget {
+  final CourseModel course;
+
+  const CourseDetailView({super.key, required this.course});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(course.title),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildMetadataCard(context),
+            const SizedBox(height: 24),
+            Text(
+              'Description',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              course.description.isNotEmpty
+                  ? course.description
+                  : 'No description provided for this course.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+                height: 1.5,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'Content',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              course.content.isNotEmpty
+                  ? course.content
+                  : 'This course does not include additional content yet.',
+              style: theme.textTheme.bodyLarge?.copyWith(height: 1.6),
+            ),
+            const SizedBox(height: 32),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                icon: const Icon(Icons.picture_as_pdf_outlined),
+                label: const Text('Download as PDF'),
+                onPressed: () => _downloadPdf(context),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetadataCard(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surface,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
+      child: Padding(
+        padding: const EdgeInsets.all(20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _buildMetadataRow(
+              context,
+              icon: Icons.menu_book_outlined,
+              label: 'Subject',
+              value: course.subjectName.isNotEmpty
+                  ? course.subjectName
+                  : 'Subject not specified',
+            ),
+            const SizedBox(height: 12),
+            _buildMetadataRow(
+              context,
+              icon: Icons.person_outline,
+              label: 'Teacher',
+              value: course.teacherName.isNotEmpty
+                  ? course.teacherName
+                  : 'Teacher unknown',
+            ),
+            const SizedBox(height: 16),
+            Text(
+              'Assigned Classes',
+              style: theme.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            if (course.classNames.isEmpty)
+              Text(
+                'This course is not linked to any class.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              )
+            else
+              Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: course.classNames
+                    .map(
+                      (name) => Chip(
+                        label: Text(name),
+                        backgroundColor:
+                            theme.colorScheme.primary.withOpacity(0.08),
+                        labelStyle: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.primary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    )
+                    .toList(),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetadataRow(BuildContext context,
+      {required IconData icon, required String label, required String value}) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          padding: const EdgeInsets.all(10),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primary.withOpacity(0.12),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(
+            icon,
+            color: theme.colorScheme.primary,
+          ),
+        ),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                label,
+                style: theme.textTheme.labelMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                value,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Future<void> _downloadPdf(BuildContext context) async {
+    final doc = pw.Document();
+    final classList = course.classNames.isEmpty
+        ? 'No classes assigned'
+        : course.classNames.join(', ');
+
+    doc.addPage(
+      pw.MultiPage(
+        build: (pw.Context context) => [
+          pw.Header(
+            level: 0,
+            child: pw.Text(
+              course.title,
+              style: pw.TextStyle(
+                fontSize: 24,
+                fontWeight: pw.FontWeight.bold,
+              ),
+            ),
+          ),
+          pw.SizedBox(height: 12),
+          pw.Text(
+            'Subject: ${course.subjectName.isNotEmpty ? course.subjectName : 'Subject not specified'}',
+            style: const pw.TextStyle(fontSize: 14),
+          ),
+          pw.Text(
+            'Teacher: ${course.teacherName.isNotEmpty ? course.teacherName : 'Teacher unknown'}',
+            style: const pw.TextStyle(fontSize: 14),
+          ),
+          pw.Text(
+            'Classes: $classList',
+            style: const pw.TextStyle(fontSize: 14),
+          ),
+          pw.SizedBox(height: 24),
+          pw.Text(
+            'Description',
+            style: pw.TextStyle(
+              fontSize: 18,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.Text(
+            course.description.isNotEmpty
+                ? course.description
+                : 'No description provided for this course.',
+            style: const pw.TextStyle(fontSize: 13),
+          ),
+          pw.SizedBox(height: 20),
+          pw.Text(
+            'Content',
+            style: pw.TextStyle(
+              fontSize: 18,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.Text(
+            course.content.isNotEmpty
+                ? course.content
+                : 'This course does not include additional content yet.',
+            style: const pw.TextStyle(fontSize: 13, height: 1.5),
+          ),
+        ],
+      ),
+    );
+
+    try {
+      final bytes = await doc.save();
+      final sanitizedTitle = course.title
+          .toLowerCase()
+          .replaceAll(RegExp('[^a-z0-9]+'), '_')
+          .replaceAll(RegExp('_+'), '_')
+          .trim();
+      final fileName = sanitizedTitle.isNotEmpty
+          ? '${sanitizedTitle}_course.pdf'
+          : 'course.pdf';
+      await Printing.sharePdf(
+        bytes: bytes,
+        filename: fileName,
+      );
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to generate the PDF. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+}

--- a/lib/modules/courses/views/course_form_view.dart
+++ b/lib/modules/courses/views/course_form_view.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../controllers/teacher_courses_controller.dart';
+
+class CourseFormView extends StatelessWidget {
+  final TeacherCoursesController controller;
+
+  const CourseFormView({super.key, required this.controller});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subjectName = controller.subject.value?.name ?? 'Subject not set';
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(controller.editing == null ? 'Add Course' : 'Edit Course'),
+        centerTitle: true,
+      ),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Form(
+          key: controller.formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Card(
+                elevation: 0,
+                color: theme.colorScheme.primary.withOpacity(0.08),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(16),
+                ),
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: Row(
+                    children: [
+                      Icon(
+                        Icons.menu_book_outlined,
+                        color: theme.colorScheme.primary,
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              'Subject',
+                              style: theme.textTheme.labelMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              subjectName,
+                              style: theme.textTheme.titleMedium?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+              const SizedBox(height: 24),
+              TextFormField(
+                controller: controller.titleController,
+                textInputAction: TextInputAction.next,
+                decoration: const InputDecoration(
+                  labelText: 'Course title',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a title';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                controller: controller.descriptionController,
+                minLines: 2,
+                maxLines: 4,
+                decoration: const InputDecoration(
+                  labelText: 'Description',
+                  border: OutlineInputBorder(),
+                  alignLabelWithHint: true,
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Please enter a brief description';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 20),
+              TextFormField(
+                controller: controller.contentController,
+                minLines: 5,
+                maxLines: 10,
+                decoration: const InputDecoration(
+                  labelText: 'Content',
+                  border: OutlineInputBorder(),
+                  alignLabelWithHint: true,
+                  hintText: 'Add the detailed course content here...'
+                      ' This will be available in the PDF download.',
+                ),
+                validator: (value) {
+                  if (value == null || value.trim().isEmpty) {
+                    return 'Course content is required';
+                  }
+                  return null;
+                },
+              ),
+              const SizedBox(height: 24),
+              Text(
+                'Assign to classes',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Obx(() {
+                if (controller.availableClasses.isEmpty) {
+                  return Container(
+                    width: double.infinity,
+                    padding: const EdgeInsets.all(16),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      color: theme.colorScheme.error.withOpacity(0.08),
+                    ),
+                    child: Text(
+                      'No classes are linked to your subject yet. Contact the administrator.',
+                      style: theme.textTheme.bodyMedium?.copyWith(
+                        color: theme.colorScheme.error,
+                      ),
+                    ),
+                  );
+                }
+                return Wrap(
+                  spacing: 8,
+                  runSpacing: 8,
+                  children: controller.availableClasses
+                      .map(
+                        (schoolClass) => FilterChip(
+                          label: Text(schoolClass.name),
+                          selected: controller.selectedClassIds
+                              .contains(schoolClass.id),
+                          onSelected: (_) =>
+                              controller.toggleClassSelection(schoolClass.id),
+                        ),
+                      )
+                      .toList(),
+                );
+              }),
+              const SizedBox(height: 32),
+              Obx(() {
+                final saving = controller.isSaving.value;
+                return SizedBox(
+                  width: double.infinity,
+                  child: ElevatedButton.icon(
+                    icon: saving
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : const Icon(Icons.save_outlined),
+                    label: Text(saving ? 'Saving...' : 'Save Course'),
+                    onPressed: saving ? null : controller.saveCourse,
+                  ),
+                );
+              }),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/courses/views/parent_courses_view.dart
+++ b/lib/modules/courses/views/parent_courses_view.dart
@@ -1,0 +1,303 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../data/models/course_model.dart';
+import '../controllers/parent_courses_controller.dart';
+import 'course_detail_view.dart';
+
+class ParentCoursesView extends StatelessWidget {
+  final ParentCoursesController controller =
+      Get.put(ParentCoursesController());
+
+  ParentCoursesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Courses'),
+        centerTitle: true,
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.children.isEmpty) {
+          return _buildNoChildrenState(context);
+        }
+        return Column(
+          children: [
+            _buildFilters(context),
+            Expanded(
+              child: Obx(() {
+                if (controller.courses.isEmpty) {
+                  return _buildEmptyState(context);
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                  itemCount: controller.courses.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final course = controller.courses[index];
+                    return _ParentCourseTile(course: course);
+                  },
+                );
+              }),
+            ),
+          ],
+        );
+      }),
+    );
+  }
+
+  Widget _buildFilters(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Filter courses',
+            style: theme.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Row(
+            children: [
+              Expanded(
+                child: Obx(() {
+                  return DropdownButtonFormField<String>(
+                    value: controller.selectedChildId.value.isEmpty
+                        ? null
+                        : controller.selectedChildId.value,
+                    decoration: const InputDecoration(
+                      labelText: 'Child',
+                      border: OutlineInputBorder(),
+                    ),
+                    hint: const Text('All children'),
+                    items: [
+                      const DropdownMenuItem<String>(
+                        value: '',
+                        child: Text('All children'),
+                      ),
+                      ...controller.children
+                          .map(
+                            (child) => DropdownMenuItem<String>(
+                              value: child.id,
+                              child: Text(child.name),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) =>
+                        controller.updateChildFilter(value ?? ''),
+                  );
+                }),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Obx(() {
+                  final options = controller.subjectOptions;
+                  return DropdownButtonFormField<String>(
+                    value: controller.selectedSubjectId.value.isEmpty
+                        ? null
+                        : controller.selectedSubjectId.value,
+                    decoration: const InputDecoration(
+                      labelText: 'Subject',
+                      border: OutlineInputBorder(),
+                    ),
+                    hint: const Text('All subjects'),
+                    items: [
+                      const DropdownMenuItem<String>(
+                        value: '',
+                        child: Text('All subjects'),
+                      ),
+                      ...options
+                          .map(
+                            (subject) => DropdownMenuItem<String>(
+                              value: subject.id,
+                              child: Text(subject.name),
+                            ),
+                          )
+                          .toList(),
+                    ],
+                    onChanged: (value) =>
+                        controller.updateSubjectFilter(value ?? ''),
+                  );
+                }),
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.menu_book_outlined,
+                color: theme.colorScheme.primary,
+                size: 40,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No courses found',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'There are no courses for the selected filters yet.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNoChildrenState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.diversity_3_outlined,
+              size: 64,
+              color: theme.colorScheme.primary,
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No children linked',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Please contact the school administration to link your children.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ParentCourseTile extends StatelessWidget {
+  final CourseModel course;
+
+  const _ParentCourseTile({required this.course});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final subject = course.subjectName.isNotEmpty
+        ? course.subjectName
+        : 'Subject not specified';
+    final classes = course.classNames.isEmpty
+        ? 'No class linked'
+        : course.classNames.join(', ');
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => Get.to(() => CourseDetailView(course: course)),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: theme.colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.08),
+                blurRadius: 18,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  course.title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 12),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.menu_book_outlined,
+                      size: 18,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        subject,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.group_outlined,
+                      size: 18,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        classes,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/courses/views/teacher_courses_view.dart
+++ b/lib/modules/courses/views/teacher_courses_view.dart
@@ -1,0 +1,237 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+
+import '../../../data/models/course_model.dart';
+import '../controllers/teacher_courses_controller.dart';
+import 'course_detail_view.dart';
+
+class TeacherCoursesView extends StatelessWidget {
+  final TeacherCoursesController controller =
+      Get.put(TeacherCoursesController());
+
+  TeacherCoursesView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('My Courses'),
+        centerTitle: true,
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.courses.isEmpty) {
+          return _buildEmptyState(context);
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 100),
+          physics: const BouncingScrollPhysics(),
+          itemCount: controller.courses.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 16),
+          itemBuilder: (context, index) {
+            final course = controller.courses[index];
+            return Dismissible(
+              key: ValueKey(course.id),
+              background: _buildEditBackground(context),
+              secondaryBackground: _buildDeleteBackground(context),
+              confirmDismiss: (direction) async {
+                if (direction == DismissDirection.startToEnd) {
+                  controller.openForm(course: course);
+                  return false;
+                }
+                final confirmed = await _confirmDelete(context);
+                if (confirmed == true) {
+                  await controller.deleteCourse(course.id);
+                }
+                return confirmed ?? false;
+              },
+              child: _CourseListTile(course: course),
+            );
+          },
+        );
+      }),
+      floatingActionButton: Obx(() {
+        final hasClasses = controller.availableClasses.isNotEmpty;
+        return FloatingActionButton.extended(
+          heroTag: 'teacherCoursesFab',
+          onPressed: hasClasses ? () => controller.openForm() : null,
+          icon: const Icon(Icons.add),
+          label: Text(hasClasses ? 'New Course' : 'No classes available'),
+        );
+      }),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    final theme = Theme.of(context);
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(32),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              width: 88,
+              height: 88,
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(
+                Icons.menu_book_outlined,
+                color: theme.colorScheme.primary,
+                size: 40,
+              ),
+            ),
+            const SizedBox(height: 24),
+            Text(
+              'No courses yet',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Tap the button below to publish your first course.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildEditBackground(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      alignment: Alignment.centerLeft,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.primary.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Icon(
+        Icons.edit_outlined,
+        color: theme.colorScheme.primary,
+        size: 28,
+      ),
+    );
+  }
+
+  Widget _buildDeleteBackground(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      alignment: Alignment.centerRight,
+      padding: const EdgeInsets.symmetric(horizontal: 24),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.error.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Icon(
+        Icons.delete_outline,
+        color: theme.colorScheme.error,
+        size: 28,
+      ),
+    );
+  }
+
+  Future<bool?> _confirmDelete(BuildContext context) {
+    final theme = Theme.of(context);
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete course'),
+        content: const Text('Are you sure you want to delete this course?'),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(false),
+            child: Text(
+              'Cancel',
+              style: TextStyle(color: theme.colorScheme.onSurfaceVariant),
+            ),
+          ),
+          TextButton(
+            onPressed: () => Navigator.of(context).pop(true),
+            child: Text(
+              'Delete',
+              style: TextStyle(color: theme.colorScheme.error),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _CourseListTile extends StatelessWidget {
+  final CourseModel course;
+
+  const _CourseListTile({required this.course});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final classes = course.classNames.isEmpty
+        ? 'No class assigned'
+        : course.classNames.join(', ');
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: () => Get.to(() => CourseDetailView(course: course)),
+        child: Ink(
+          decoration: BoxDecoration(
+            borderRadius: BorderRadius.circular(20),
+            color: theme.colorScheme.surface,
+            boxShadow: [
+              BoxShadow(
+                color: theme.colorScheme.primary.withOpacity(0.08),
+                blurRadius: 18,
+                offset: const Offset(0, 10),
+              ),
+            ],
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  course.title,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      Icons.group_outlined,
+                      size: 18,
+                      color: theme.colorScheme.primary,
+                    ),
+                    const SizedBox(width: 6),
+                    Expanded(
+                      child: Text(
+                        classes,
+                        style: theme.textTheme.bodyMedium?.copyWith(
+                          color: theme.colorScheme.onSurfaceVariant,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/modules/parents_dashboard/views/parent_dashboard_view.dart
+++ b/lib/modules/parents_dashboard/views/parent_dashboard_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/widgets/dashboard_card.dart';
 import '../../../core/widgets/role_dashboard.dart';
+import '../../../app/routes/app_pages.dart';
 import '../controllers/parent_controller.dart';
 
 class ParentDashboard extends StatelessWidget {
@@ -20,6 +21,13 @@ class ParentDashboard extends StatelessWidget {
           subtitle: 'School notices',
           color: Colors.purple,
           onTap: () => Get.toNamed('/parent/announcements'),
+        ),
+        DashboardCard(
+          icon: Icons.menu_book,
+          title: 'Courses',
+          subtitle: 'View class materials',
+          color: Colors.teal,
+          onTap: () => Get.toNamed(AppPages.PARENT_COURSES),
         ),
         DashboardCard(
           icon: Icons.message,

--- a/lib/modules/teachers_dashboard/views/teacher_dashboard_view.dart
+++ b/lib/modules/teachers_dashboard/views/teacher_dashboard_view.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../../core/widgets/dashboard_card.dart';
 import '../../../core/widgets/role_dashboard.dart';
+import '../../../app/routes/app_pages.dart';
 import '../controllers/teacher_controller.dart';
 
 class TeacherDashboard extends StatelessWidget {
@@ -14,6 +15,13 @@ class TeacherDashboard extends StatelessWidget {
       roleName: 'Teacher',
       onLogout: _controller.logout,
       cards: [
+        DashboardCard(
+          icon: Icons.menu_book,
+          title: 'Courses',
+          subtitle: 'Create and share lessons',
+          color: Colors.teal,
+          onTap: () => Get.toNamed(AppPages.TEACHER_COURSES),
+        ),
         DashboardCard(
           icon: Icons.school,
           title: 'My Classes',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   flutter_dotenv: ^5.2.1
   animated_splash_screen: ^1.3.0
   intl: ^0.19.0
+  pdf: ^3.11.0
+  printing: ^5.13.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add a CourseModel with Firestore integration for streaming and CRUD helpers
- implement teacher, parent, and admin course controllers with list, filter, and edit/delete capabilities plus shared views including form and detail PDF export
- wire new course routes into dashboards so each role can navigate to the module

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cab67f84a08331aff76e9ccbbd1407