### PR TITLE
Enhance admin announcements and courses experiences

### DIFF
--- a/lib/modules/announcement/views/announcement_detail_view.dart
+++ b/lib/modules/announcement/views/announcement_detail_view.dart
@@ -1,12 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import 'package:intl/intl.dart';
+import 'package:pdf/widgets.dart' as pw;
+import 'package:printing/printing.dart';
 
 import '../../../data/models/announcement_model.dart';
 
 class AnnouncementDetailView extends StatelessWidget {
   final AnnouncementModel announcement;
+  final bool isAdmin;
 
-  AnnouncementDetailView({super.key, required this.announcement});
+  AnnouncementDetailView({
+    super.key,
+    required this.announcement,
+    this.isAdmin = false,
+  });
 
   final DateFormat _dateFormat = DateFormat('EEEE, MMM d, yyyy • h:mm a');
 
@@ -20,6 +28,14 @@ class AnnouncementDetailView extends StatelessWidget {
       appBar: AppBar(
         title: const Text('Announcement'),
         centerTitle: true,
+        actions: [
+          if (isAdmin)
+            IconButton(
+              tooltip: 'Download PDF',
+              icon: const Icon(Icons.picture_as_pdf_outlined),
+              onPressed: () => _downloadPdf(context),
+            ),
+        ],
       ),
       body: Container(
         decoration: BoxDecoration(
@@ -85,6 +101,26 @@ class AnnouncementDetailView extends StatelessWidget {
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
+                                const SizedBox(height: 12),
+                                Row(
+                                  children: [
+                                    Icon(
+                                      Icons.hourglass_bottom,
+                                      size: 18,
+                                      color: theme.colorScheme.secondary,
+                                    ),
+                                    const SizedBox(width: 6),
+                                    Text(
+                                      _expiryDescription(),
+                                      style:
+                                          theme.textTheme.bodySmall?.copyWith(
+                                        color: theme
+                                            .colorScheme.onSurfaceVariant,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ],
                             ),
                           ),
@@ -122,6 +158,47 @@ class AnnouncementDetailView extends StatelessWidget {
                           height: 1.6,
                         ),
                       ),
+                      if (isAdmin) ...[
+                        const SizedBox(height: 32),
+                        Container(
+                          width: double.infinity,
+                          decoration: BoxDecoration(
+                            color: theme.colorScheme.surfaceVariant
+                                .withOpacity(0.4),
+                            borderRadius: BorderRadius.circular(18),
+                          ),
+                          padding: const EdgeInsets.all(18),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              Text(
+                                'Admin tools',
+                                style: theme.textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                              const SizedBox(height: 12),
+                              Text(
+                                'Download a formatted PDF copy for records or offline sharing.',
+                                style: theme.textTheme.bodyMedium?.copyWith(
+                                  color: theme
+                                      .colorScheme.onSurfaceVariant,
+                                ),
+                              ),
+                              const SizedBox(height: 16),
+                              SizedBox(
+                                width: double.infinity,
+                                child: ElevatedButton.icon(
+                                  icon: const Icon(
+                                      Icons.picture_as_pdf_outlined),
+                                  label: const Text('Download announcement PDF'),
+                                  onPressed: () => _downloadPdf(context),
+                                ),
+                              ),
+                            ],
+                          ),
+                        ),
+                      ],
                     ],
                   ),
                 ),
@@ -177,5 +254,116 @@ class AnnouncementDetailView extends StatelessWidget {
       backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
     );
+  }
+
+  String _expiryDescription() {
+    final expiry = announcement.createdAt.add(const Duration(days: 7));
+    final remaining = expiry.difference(DateTime.now());
+    if (remaining.isNegative) {
+      return 'Expired on ${DateFormat('MMM d, yyyy').format(expiry)}';
+    }
+    if (remaining.inDays > 0) {
+      return 'Expires in ${remaining.inDays} day${remaining.inDays == 1 ? '' : 's'}';
+    }
+    if (remaining.inHours > 0) {
+      return 'Expires in ${remaining.inHours} hour${remaining.inHours == 1 ? '' : 's'}';
+    }
+    return 'Expires soon';
+  }
+
+  Future<void> _downloadPdf(BuildContext context) async {
+    final doc = pw.Document();
+    final audience = _audienceLabels();
+    final dateText = _dateFormat.format(announcement.createdAt);
+    final expiry = announcement.createdAt.add(const Duration(days: 7));
+
+    doc.addPage(
+      pw.MultiPage(
+        build: (_) => [
+          pw.Header(
+            child: pw.Column(
+              crossAxisAlignment: pw.CrossAxisAlignment.start,
+              children: [
+                pw.Text(
+                  announcement.title,
+                  style: pw.TextStyle(
+                    fontSize: 24,
+                    fontWeight: pw.FontWeight.bold,
+                  ),
+                ),
+                pw.SizedBox(height: 4),
+                pw.Text(
+                  'Published: $dateText',
+                  style: const pw.TextStyle(fontSize: 12),
+                ),
+              ],
+            ),
+          ),
+          pw.SizedBox(height: 16),
+          pw.Text(
+            'Audience',
+            style: pw.TextStyle(
+              fontSize: 16,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 6),
+          pw.Text(
+            audience.isEmpty
+                ? 'All audiences'
+                : audience.join(', '),
+            style: const pw.TextStyle(fontSize: 12),
+          ),
+          pw.SizedBox(height: 16),
+          pw.Text(
+            'Announcement',
+            style: pw.TextStyle(
+              fontSize: 16,
+              fontWeight: pw.FontWeight.bold,
+            ),
+          ),
+          pw.SizedBox(height: 8),
+          pw.Text(
+            announcement.description,
+            style: const pw.TextStyle(fontSize: 13, height: 1.5),
+          ),
+          pw.SizedBox(height: 20),
+          pw.Text(
+            'Expires on ${DateFormat('MMM d, yyyy • h:mm a').format(expiry)}',
+            style: const pw.TextStyle(fontSize: 11),
+          ),
+        ],
+      ),
+    );
+
+    try {
+      final bytes = await doc.save();
+      final sanitized = _sanitizeFileName(announcement.title);
+      final fileName =
+          sanitized.isEmpty ? 'announcement.pdf' : '$sanitized.pdf';
+      await Printing.sharePdf(bytes: bytes, filename: fileName);
+      Get.closeCurrentSnackbar();
+      Get.snackbar(
+        'Download ready',
+        'The announcement PDF was generated successfully.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } catch (e) {
+      Get.closeCurrentSnackbar();
+      Get.snackbar(
+        'Download failed',
+        'Unable to generate the PDF. ${e.toString()}',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+
+  String _sanitizeFileName(String value) {
+    final trimmed = value.trim().isEmpty ? 'announcement' : value.trim();
+    final sanitized = trimmed
+        .replaceAll(RegExp(r'[\\/:*?"<>|]'), '')
+        .replaceAll(RegExp(r'\s+'), ' ')
+        .replaceAll(' ', '_');
+    return sanitized.toLowerCase();
   }
 }

--- a/lib/modules/announcement/views/announcement_form_view.dart
+++ b/lib/modules/announcement/views/announcement_form_view.dart
@@ -10,43 +10,300 @@ class AnnouncementFormView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final theme = Theme.of(context);
     final isEditing = controller.editing != null;
     return Scaffold(
       appBar: AppBar(
         title: Text(isEditing ? 'Edit Announcement' : 'Add Announcement'),
+        centerTitle: true,
       ),
-      body: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          children: [
-            TextField(
-              controller: controller.titleController,
-              decoration: const InputDecoration(labelText: 'Title'),
-            ),
-            const SizedBox(height: 16),
-            TextField(
-              controller: controller.descriptionController,
-              decoration: const InputDecoration(labelText: 'Description'),
-              maxLines: 3,
-            ),
-            Obx(() => CheckboxListTile(
-                  value: controller.teachersSelected.value,
-                  onChanged: (v) => controller.teachersSelected.value = v ?? false,
-                  title: const Text('Teachers'),
-                )),
-            Obx(() => CheckboxListTile(
-                  value: controller.parentsSelected.value,
-                  onChanged: (v) => controller.parentsSelected.value = v ?? false,
-                  title: const Text('Parents'),
-                )),
-            const SizedBox(height: 16),
-            ElevatedButton(
-              onPressed: controller.saveAnnouncement,
-              child: const Text('Save'),
-            )
-          ],
+      body: GestureDetector(
+        onTap: () => FocusScope.of(context).unfocus(),
+        child: LayoutBuilder(
+          builder: (context, constraints) {
+            return SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 20),
+              child: Center(
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 640),
+                  child: Form(
+                    key: controller.formKey,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Card(
+                          elevation: 0,
+                          color: theme.colorScheme.primary.withOpacity(0.08),
+                          shape: RoundedRectangleBorder(
+                            borderRadius: BorderRadius.circular(20),
+                          ),
+                          child: Padding(
+                            padding: const EdgeInsets.all(20),
+                            child: Row(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Container(
+                                  padding: const EdgeInsets.all(12),
+                                  decoration: BoxDecoration(
+                                    color: theme.colorScheme.primary
+                                        .withOpacity(0.18),
+                                    borderRadius: BorderRadius.circular(16),
+                                  ),
+                                  child: Icon(
+                                    Icons.campaign_outlined,
+                                    color: theme.colorScheme.primary,
+                                    size: 26,
+                                  ),
+                                ),
+                                const SizedBox(width: 16),
+                                Expanded(
+                                  child: Column(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      Text(
+                                        isEditing
+                                            ? 'Update the announcement details'
+                                            : 'Share a new announcement',
+                                        style: theme.textTheme.titleMedium?.copyWith(
+                                          fontWeight: FontWeight.w700,
+                                        ),
+                                      ),
+                                      const SizedBox(height: 8),
+                                      Text(
+                                        'Announcements automatically expire after seven days. Make sure to provide a clear title and concise information.',
+                                        style: theme.textTheme.bodyMedium?.copyWith(
+                                          color: theme.colorScheme.onSurfaceVariant,
+                                          height: 1.4,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ),
+                        const SizedBox(height: 28),
+                        TextFormField(
+                          controller: controller.titleController,
+                          textInputAction: TextInputAction.next,
+                          decoration: const InputDecoration(
+                            labelText: 'Announcement title',
+                            border: OutlineInputBorder(),
+                            hintText: 'e.g. Midterm exams schedule',
+                          ),
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Please enter a title.';
+                            }
+                            if (value.trim().length < 4) {
+                              return 'The title should be at least 4 characters long.';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 24),
+                        TextFormField(
+                          controller: controller.descriptionController,
+                          minLines: 5,
+                          maxLines: 12,
+                          maxLength: 600,
+                          decoration: const InputDecoration(
+                            labelText: 'Message',
+                            alignLabelWithHint: true,
+                            border: OutlineInputBorder(),
+                            hintText:
+                                'Share the announcement details, dates and any important instructions.',
+                            counterText: '',
+                          ),
+                          validator: (value) {
+                            if (value == null || value.trim().isEmpty) {
+                              return 'Please describe the announcement.';
+                            }
+                            if (value.trim().length < 10) {
+                              return 'Add a bit more context so everyone understands.';
+                            }
+                            return null;
+                          },
+                        ),
+                        const SizedBox(height: 12),
+                        ValueListenableBuilder<TextEditingValue>(
+                          valueListenable: controller.descriptionController,
+                          builder: (context, value, _) {
+                            final remaining = 600 - value.text.length;
+                            return Align(
+                              alignment: Alignment.centerRight,
+                              child: Text(
+                                remaining >= 0
+                                    ? '$remaining characters left'
+                                    : 'Limit exceeded by ${remaining.abs()} characters',
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: remaining >= 0
+                                      ? theme.colorScheme.onSurfaceVariant
+                                      : theme.colorScheme.error,
+                                ),
+                              ),
+                            );
+                          },
+                        ),
+                        const SizedBox(height: 32),
+                        Text(
+                          'Audience',
+                          style: theme.textTheme.titleMedium?.copyWith(
+                            fontWeight: FontWeight.w600,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Obx(
+                          () => Wrap(
+                            spacing: 12,
+                            runSpacing: 12,
+                            children: [
+                              _buildAudienceChip(
+                                context,
+                                label: 'Teachers',
+                                icon: Icons.school_outlined,
+                                selected: controller.teachersSelected.value,
+                                onChanged: (value) =>
+                                    controller.teachersSelected.value = value,
+                              ),
+                              _buildAudienceChip(
+                                context,
+                                label: 'Parents',
+                                icon: Icons.family_restroom_outlined,
+                                selected: controller.parentsSelected.value,
+                                onChanged: (value) =>
+                                    controller.parentsSelected.value = value,
+                              ),
+                            ],
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Obx(() {
+                          final hasSelection = controller.teachersSelected.value ||
+                              controller.parentsSelected.value;
+                          final selectedGroups = <String>[];
+                          if (controller.teachersSelected.value) {
+                            selectedGroups.add('Teachers');
+                          }
+                          if (controller.parentsSelected.value) {
+                            selectedGroups.add('Parents');
+                          }
+                          return AnimatedContainer(
+                            duration: const Duration(milliseconds: 200),
+                            padding: const EdgeInsets.symmetric(
+                                horizontal: 16, vertical: 12),
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(16),
+                              color: hasSelection
+                                  ? theme.colorScheme.surfaceVariant
+                                      .withOpacity(0.45)
+                                  : theme.colorScheme.error.withOpacity(0.1),
+                            ),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  hasSelection
+                                      ? Icons.check_circle_outline
+                                      : Icons.error_outline,
+                                  color: hasSelection
+                                      ? theme.colorScheme.primary
+                                      : theme.colorScheme.error,
+                                ),
+                                const SizedBox(width: 12),
+                                Expanded(
+                                  child: Text(
+                                    hasSelection
+                                        ? 'Will notify: ${selectedGroups.join(', ')}'
+                                        : 'Select at least one audience to notify.',
+                                    style: theme.textTheme.bodyMedium?.copyWith(
+                                      color: hasSelection
+                                          ? theme.colorScheme.onSurfaceVariant
+                                          : theme.colorScheme.error,
+                                    ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          );
+                        }),
+                        const SizedBox(height: 36),
+                        Obx(() {
+                          final saving = controller.isSaving.value;
+                          return SizedBox(
+                            width: double.infinity,
+                            child: ElevatedButton.icon(
+                              icon: saving
+                                  ? const SizedBox(
+                                      width: 20,
+                                      height: 20,
+                                      child: CircularProgressIndicator(
+                                        strokeWidth: 2,
+                                      ),
+                                    )
+                                  : Icon(
+                                      isEditing
+                                          ? Icons.save_outlined
+                                          : Icons.send_rounded,
+                                    ),
+                              label: Text(
+                                saving
+                                    ? 'Saving...'
+                                    : isEditing
+                                        ? 'Update announcement'
+                                        : 'Publish announcement',
+                              ),
+                              onPressed:
+                                  saving ? null : controller.saveAnnouncement,
+                            ),
+                          );
+                        }),
+                      ],
+                    ),
+                  ),
+                ),
+              ),
+            );
+          },
         ),
       ),
+    );
+  }
+
+  Widget _buildAudienceChip(
+    BuildContext context, {
+    required String label,
+    required IconData icon,
+    required bool selected,
+    required ValueChanged<bool> onChanged,
+  }) {
+    final theme = Theme.of(context);
+    return FilterChip(
+      avatar: Icon(
+        icon,
+        color: selected
+            ? theme.colorScheme.onPrimary
+            : theme.colorScheme.primary,
+      ),
+      label: Text(label),
+      selected: selected,
+      onSelected: onChanged,
+      showCheckmark: false,
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      selectedColor: theme.colorScheme.primary,
+      labelStyle: theme.textTheme.bodyMedium?.copyWith(
+        color: selected
+            ? theme.colorScheme.onPrimary
+            : theme.colorScheme.onSurface,
+        fontWeight: FontWeight.w600,
+      ),
+      side: BorderSide(
+        color: selected
+            ? theme.colorScheme.primary
+            : theme.colorScheme.primary.withOpacity(0.4),
+      ),
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
     );
   }
 }

--- a/lib/modules/courses/views/admin_courses_view.dart
+++ b/lib/modules/courses/views/admin_courses_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
 
 import '../../../data/models/course_model.dart';
 import '../controllers/admin_courses_controller.dart';
@@ -24,26 +25,99 @@ class AdminCoursesView extends StatelessWidget {
         }
         return Column(
           children: [
+            _buildSearchAndStats(context),
             _buildFilters(context),
             Expanded(
-              child: Obx(() {
-                if (controller.courses.isEmpty) {
-                  return _buildEmptyState(context);
-                }
-                return ListView.separated(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                  itemCount: controller.courses.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 16),
-                  itemBuilder: (context, index) {
-                    final course = controller.courses[index];
-                    return _AdminCourseTile(course: course);
-                  },
-                );
-              }),
+              child: controller.courses.isEmpty
+                  ? _buildEmptyState(context)
+                  : ListView.separated(
+                      padding: const EdgeInsets.fromLTRB(16, 8, 16, 32),
+                      itemCount: controller.courses.length,
+                      physics: const BouncingScrollPhysics(),
+                      separatorBuilder: (_, __) => const SizedBox(height: 18),
+                      itemBuilder: (context, index) {
+                        final course = controller.courses[index];
+                        return _AdminCourseTile(course: course);
+                      },
+                    ),
             ),
           ],
         );
       }),
+    );
+  }
+
+  Widget _buildSearchAndStats(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 20, 16, 12),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          TextField(
+            controller: controller.searchController,
+            decoration: InputDecoration(
+              hintText: 'Search by course, subject, teacher or class',
+              prefixIcon: const Icon(Icons.search),
+              suffixIcon: Obx(
+                () => controller.searchQuery.value.isEmpty
+                    ? null
+                    : IconButton(
+                        tooltip: 'Clear search',
+                        icon: const Icon(Icons.close),
+                        onPressed: controller.searchController.clear,
+                      ),
+              ),
+              filled: true,
+              fillColor: theme.colorScheme.surface,
+              border: OutlineInputBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+            ),
+            textInputAction: TextInputAction.search,
+          ),
+          const SizedBox(height: 16),
+          Obx(() {
+            final filteredCount = controller.courses.length;
+            final totalCount = controller.totalCourseCount;
+            final filteredTeachers = controller.filteredTeacherCount;
+            final filteredSubjects = controller.filteredSubjectCount;
+            final filteredClasses = controller.filteredClassCount;
+            return Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: [
+                _buildSummaryCard(
+                  context,
+                  icon: Icons.menu_book_outlined,
+                  label: 'Visible courses',
+                  value: totalCount > 0
+                      ? '$filteredCount of $totalCount'
+                      : '$filteredCount',
+                ),
+                _buildSummaryCard(
+                  context,
+                  icon: Icons.groups_outlined,
+                  label: 'Teachers represented',
+                  value: filteredTeachers.toString(),
+                ),
+                _buildSummaryCard(
+                  context,
+                  icon: Icons.category_outlined,
+                  label: 'Subjects',
+                  value: filteredSubjects.toString(),
+                ),
+                _buildSummaryCard(
+                  context,
+                  icon: Icons.class_outlined,
+                  label: 'Classes covered',
+                  value: filteredClasses.toString(),
+                ),
+              ],
+            );
+          }),
+        ],
+      ),
     );
   }
 
@@ -66,7 +140,8 @@ class AdminCoursesView extends StatelessWidget {
               Obx(() {
                 final hasFilters = controller.selectedSubjectId.value.isNotEmpty ||
                     controller.selectedTeacherId.value.isNotEmpty ||
-                    controller.selectedClassId.value.isNotEmpty;
+                    controller.selectedClassId.value.isNotEmpty ||
+                    controller.searchQuery.value.isNotEmpty;
                 return TextButton.icon(
                   onPressed: hasFilters ? controller.clearFilters : null,
                   icon: const Icon(Icons.filter_alt_off_outlined, size: 18),
@@ -75,6 +150,53 @@ class AdminCoursesView extends StatelessWidget {
               }),
             ],
           ),
+          const SizedBox(height: 12),
+          Obx(() {
+            final chips = <Widget>[];
+            if (controller.searchQuery.value.isNotEmpty) {
+              chips.add(_buildActiveFilterChip(
+                context,
+                label: 'Search: ${controller.searchQuery.value}',
+                onRemoved: controller.searchController.clear,
+              ));
+            }
+            if (controller.selectedSubjectId.value.isNotEmpty) {
+              chips.add(_buildActiveFilterChip(
+                context,
+                label:
+                    'Subject: ${controller.subjectName(controller.selectedSubjectId.value)}',
+                onRemoved: () => controller.updateSubjectFilter(''),
+              ));
+            }
+            if (controller.selectedTeacherId.value.isNotEmpty) {
+              final teacher = controller.teacherName(
+                  controller.selectedTeacherId.value);
+              chips.add(_buildActiveFilterChip(
+                context,
+                label: 'Teacher: $teacher',
+                onRemoved: () => controller.updateTeacherFilter(''),
+              ));
+            }
+            if (controller.selectedClassId.value.isNotEmpty) {
+              chips.add(_buildActiveFilterChip(
+                context,
+                label:
+                    'Class: ${controller.className(controller.selectedClassId.value)}',
+                onRemoved: () => controller.updateClassFilter(''),
+              ));
+            }
+            if (chips.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 8),
+              child: Wrap(
+                spacing: 8,
+                runSpacing: 8,
+                children: chips,
+              ),
+            );
+          }),
           const SizedBox(height: 12),
           Row(
             children: [
@@ -181,6 +303,92 @@ class AdminCoursesView extends StatelessWidget {
     );
   }
 
+  Widget _buildSummaryCard(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+    required String value,
+  }) {
+    final theme = Theme.of(context);
+    return ConstrainedBox(
+      constraints: const BoxConstraints(minWidth: 150),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 18, vertical: 16),
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surface,
+          borderRadius: BorderRadius.circular(18),
+          boxShadow: [
+            BoxShadow(
+              color: theme.colorScheme.primary.withOpacity(0.06),
+              blurRadius: 16,
+              offset: const Offset(0, 12),
+            ),
+          ],
+          border: Border.all(
+            color: theme.colorScheme.primary.withOpacity(0.1),
+          ),
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: const EdgeInsets.all(10),
+              decoration: BoxDecoration(
+                color: theme.colorScheme.primary.withOpacity(0.12),
+                shape: BoxShape.circle,
+              ),
+              child: Icon(icon, color: theme.colorScheme.primary, size: 20),
+            ),
+            const SizedBox(width: 12),
+            Flexible(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    value,
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      color: theme.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildActiveFilterChip(
+    BuildContext context, {
+    required String label,
+    required VoidCallback onRemoved,
+  }) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(
+        Icons.filter_alt_outlined,
+        size: 18,
+        color: theme.colorScheme.primary,
+      ),
+      label: Text(label),
+      deleteIcon: const Icon(Icons.close, size: 18),
+      onDeleted: onRemoved,
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+      labelStyle: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.primary,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
   Widget _buildEmptyState(BuildContext context) {
     final theme = Theme.of(context);
     return Center(
@@ -217,6 +425,14 @@ class AdminCoursesView extends StatelessWidget {
                 color: theme.colorScheme.onSurfaceVariant,
               ),
             ),
+            const SizedBox(height: 12),
+            Text(
+              'Tip: use the search box above to find a specific class or teacher.',
+              textAlign: TextAlign.center,
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
           ],
         ),
       ),
@@ -226,6 +442,7 @@ class AdminCoursesView extends StatelessWidget {
 
 class _AdminCourseTile extends StatelessWidget {
   final CourseModel course;
+  static final DateFormat _dateFormat = DateFormat('MMM d, yyyy');
 
   const _AdminCourseTile({required this.course});
 
@@ -238,6 +455,9 @@ class _AdminCourseTile extends StatelessWidget {
     final teacher = course.teacherName.isNotEmpty
         ? course.teacherName
         : 'Teacher unknown';
+    final createdLabel = _dateFormat.format(course.createdAt);
+    final isNew = DateTime.now().difference(course.createdAt).inDays < 5;
+    final uniqueClasses = course.classNames.toSet().toList();
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -260,47 +480,96 @@ class _AdminCourseTile extends StatelessWidget {
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text(
-                  course.title,
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w700,
-                  ),
-                ),
-                const SizedBox(height: 12),
                 Row(
+                  crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    Icon(
-                      Icons.person_outline,
-                      size: 18,
-                      color: theme.colorScheme.primary,
-                    ),
-                    const SizedBox(width: 6),
                     Expanded(
-                      child: Text(
-                        teacher,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            course.title,
+                            style: theme.textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w700,
+                            ),
+                          ),
+                          const SizedBox(height: 6),
+                          Text(
+                            subject,
+                            style: theme.textTheme.bodyMedium?.copyWith(
+                              color: theme.colorScheme.primary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ],
                       ),
                     ),
+                    if (isNew)
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 10, vertical: 4),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.secondary.withOpacity(0.16),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          'New',
+                          style: theme.textTheme.labelMedium?.copyWith(
+                            color: theme.colorScheme.secondary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ),
                   ],
                 ),
+                const SizedBox(height: 10),
+                Text(
+                  course.description.isNotEmpty
+                      ? course.description
+                      : 'No description provided for this course.',
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                    height: 1.4,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                _buildMetaRow(
+                  context,
+                  icon: Icons.person_outline,
+                  value: teacher,
+                ),
                 const SizedBox(height: 8),
+                _buildMetaRow(
+                  context,
+                  icon: Icons.class_outlined,
+                  value: uniqueClasses.isEmpty
+                      ? 'No classes linked yet'
+                      : '${uniqueClasses.length} class${uniqueClasses.length == 1 ? '' : 'es'} linked',
+                ),
+                if (uniqueClasses.isNotEmpty) ...[
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: uniqueClasses
+                        .map((name) => _buildClassChip(context, name))
+                        .toList(),
+                  ),
+                ],
+                const SizedBox(height: 16),
                 Row(
                   children: [
-                    Icon(
-                      Icons.menu_book_outlined,
-                      size: 18,
-                      color: theme.colorScheme.primary,
+                    _buildMetaBadge(
+                      context,
+                      icon: Icons.calendar_today_outlined,
+                      label: 'Created $createdLabel',
                     ),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        subject,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
+                    const Spacer(),
+                    Icon(
+                      Icons.arrow_forward_rounded,
+                      color: theme.colorScheme.primary,
                     ),
                   ],
                 ),
@@ -308,6 +577,76 @@ class _AdminCourseTile extends StatelessWidget {
             ),
           ),
         ),
+      ),
+    );
+  }
+
+  Widget _buildMetaRow(BuildContext context,
+      {required IconData icon, required String value}) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Container(
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primary.withOpacity(0.12),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          child: Icon(icon, size: 18, color: theme.colorScheme.primary),
+        ),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Text(
+            value,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: theme.colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildClassChip(BuildContext context, String name) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        color: theme.colorScheme.secondary.withOpacity(0.12),
+      ),
+      child: Text(
+        name,
+        style: theme.textTheme.bodySmall?.copyWith(
+          color: theme.colorScheme.secondary,
+          fontWeight: FontWeight.w600,
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMetaBadge(BuildContext context,
+      {required IconData icon, required String label}) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(14),
+        color: theme.colorScheme.primary.withOpacity(0.08),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: theme.colorScheme.primary),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: theme.colorScheme.primary,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- Redesign the announcement form with validation, improved audience selection, and admin-only PDF download options in the detail view.
- Refresh announcement cards with expiry progress indicators while routing admins to the enhanced detail view without the swipe hint.
- Add search, active filter chips, and analytics to the admin courses list plus an expanded course detail layout with better content rendering and title-based PDF names.

## Testing
- Not run (flutter command unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc60b1c7a883318cfdf97fcc47eae4