### PR TITLE
Fix suffix icon builder return type

### DIFF
--- a/lib/modules/courses/views/admin_courses_view.dart
+++ b/lib/modules/courses/views/admin_courses_view.dart
@@ -61,7 +61,7 @@ class AdminCoursesView extends StatelessWidget {
               prefixIcon: const Icon(Icons.search),
               suffixIcon: Obx(
                 () => controller.searchQuery.value.isEmpty
-                    ? null
+                    ? const SizedBox.shrink()
                     : IconButton(
                         tooltip: 'Clear search',
                         icon: const Icon(Icons.close),


### PR DESCRIPTION
## Summary
- ensure the courses search field suffix icon builder always returns a widget instead of a nullable IconButton

## Testing
- flutter analyze *(fails: Flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6a63c0188331b956aac637952f00