### PR TITLE
Limit announcement expiry info to admins and tidy admin courses

### DIFF
--- a/lib/modules/announcement/views/announcement_detail_view.dart
+++ b/lib/modules/announcement/views/announcement_detail_view.dart
@@ -101,26 +101,26 @@ class AnnouncementDetailView extends StatelessWidget {
                                     fontWeight: FontWeight.w600,
                                   ),
                                 ),
-                                const SizedBox(height: 12),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      Icons.hourglass_bottom,
-                                      size: 18,
-                                      color: theme.colorScheme.secondary,
-                                    ),
-                                    const SizedBox(width: 6),
-                                    Text(
-                                      _expiryDescription(),
-                                      style:
-                                          theme.textTheme.bodySmall?.copyWith(
-                                        color: theme
-                                            .colorScheme.onSurfaceVariant,
-                                        fontWeight: FontWeight.w600,
+                                if (isAdmin) ...[
+                                  const SizedBox(height: 12),
+                                  Row(
+                                    children: [
+                                      Icon(
+                                        Icons.hourglass_bottom,
+                                        size: 18,
+                                        color: theme.colorScheme.secondary,
                                       ),
-                                    ),
-                                  ],
-                                ),
+                                      const SizedBox(width: 6),
+                                      Text(
+                                        _expiryDescription(),
+                                        style: theme.textTheme.bodySmall?.copyWith(
+                                          color: theme.colorScheme.onSurfaceVariant,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                ],
                               ],
                             ),
                           ),

--- a/lib/modules/courses/views/admin_courses_view.dart
+++ b/lib/modules/courses/views/admin_courses_view.dart
@@ -456,7 +456,6 @@ class _AdminCourseTile extends StatelessWidget {
         ? course.teacherName
         : 'Teacher unknown';
     final createdLabel = _dateFormat.format(course.createdAt);
-    final isNew = DateTime.now().difference(course.createdAt).inDays < 5;
     final uniqueClasses = course.classNames.toSet().toList();
     return Material(
       color: Colors.transparent,
@@ -504,22 +503,6 @@ class _AdminCourseTile extends StatelessWidget {
                         ],
                       ),
                     ),
-                    if (isNew)
-                      Container(
-                        padding: const EdgeInsets.symmetric(
-                            horizontal: 10, vertical: 4),
-                        decoration: BoxDecoration(
-                          color: theme.colorScheme.secondary.withOpacity(0.16),
-                          borderRadius: BorderRadius.circular(12),
-                        ),
-                        child: Text(
-                          'New',
-                          style: theme.textTheme.labelMedium?.copyWith(
-                            color: theme.colorScheme.secondary,
-                            fontWeight: FontWeight.w700,
-                          ),
-                        ),
-                      ),
                   ],
                 ),
                 const SizedBox(height: 10),


### PR DESCRIPTION
## Summary
- hide the announcement expiry countdown from non-admin audiences while keeping it visible with an admin-only helper
- gate the expiry notice on the announcement detail page behind the admin flag
- remove the "New" chip from admin course cards for a cleaner list view

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc6f411a14833184a45f175a87f332