### PR TITLE
Refine admin announcements and course list layout

### DIFF
--- a/lib/modules/announcement/views/announcement_list_view.dart
+++ b/lib/modules/announcement/views/announcement_list_view.dart
@@ -114,8 +114,11 @@ class AnnouncementListView extends StatelessWidget {
   }) {
     final theme = Theme.of(context);
     final dateText = _dateFormat.format(ann.createdAt);
-    final audienceLabels = _audienceLabels(ann);
+    final showAudience = isAdmin || highlightForAdmin;
+    final audienceLabels =
+        showAudience ? _audienceLabels(ann) : const <String>[];
     final showExpiryDetails = isAdmin || highlightForAdmin;
+    final showAudienceTags = showAudience && audienceLabels.isNotEmpty;
 
     return Material(
       color: Colors.transparent,
@@ -203,18 +206,20 @@ class AnnouncementListView extends StatelessWidget {
                     height: 1.5,
                   ),
                 ),
-                const SizedBox(height: 16),
-                Wrap(
-                  spacing: 10,
-                  runSpacing: 8,
-                  children: audienceLabels
-                      .map((label) => _buildTagChip(
-                            context,
-                            Icons.people_outline,
-                            label,
-                          ))
-                      .toList(),
-                ),
+                if (showAudienceTags) ...[
+                  const SizedBox(height: 16),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 8,
+                    children: audienceLabels
+                        .map((label) => _buildTagChip(
+                              context,
+                              Icons.people_outline,
+                              label,
+                            ))
+                        .toList(),
+                  ),
+                ],
                 if (showExpiryDetails) ...[
                   const SizedBox(height: 16),
                   _buildExpiryStatus(


### PR DESCRIPTION
## Summary
- hide audience chips from teacher/parent announcement list cards and detail view while keeping admin visibility
- update admin announcement detail overview to show audience information only for admins and tidy badges
- restructure the admin courses list so filters sit at the top, stats render in a 2x2 grid, and the whole page scrolls together via a custom scroll view

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68cc7eafccb88331b041eecf063b3a13