### PR TITLE
Add DevNet credit to splash screen

### DIFF
--- a/lib/modules/splash/splash_view.dart
+++ b/lib/modules/splash/splash_view.dart
@@ -93,6 +93,31 @@ class _SplashViewState extends State<SplashView> {
               ],
             ),
           ),
+
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: Padding(
+              padding: const EdgeInsets.only(bottom: 40),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    'Made with',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontSize: 16,
+                      fontWeight: FontWeight.w500,
+                    ),
+                  ),
+                  SizedBox(height: 8),
+                  Image.asset(
+                    'assets/Denet_logo.png',
+                    height: 40,
+                  ),
+                ],
+              ),
+            ),
+          ),
         ],
       ),
     );


### PR DESCRIPTION
## Summary
- show "Made with" caption and DevNet logo at the bottom of the splash screen

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc865acf5083318d3121e573b2524f