### PR TITLE
feat: allow teachers to import course content from files or images

### DIFF
--- a/lib/modules/courses/views/course_form_view.dart
+++ b/lib/modules/courses/views/course_form_view.dart
@@ -96,24 +96,177 @@ class CourseFormView extends StatelessWidget {
                 },
               ),
               const SizedBox(height: 20),
-              TextFormField(
-                controller: controller.contentController,
-                minLines: 5,
-                maxLines: 10,
-                decoration: const InputDecoration(
-                  labelText: 'Content',
-                  border: OutlineInputBorder(),
-                  alignLabelWithHint: true,
-                  hintText: 'Add the detailed course content here...'
-                      ' This will be available in the PDF download.',
+              Text(
+                'Course content',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w600,
                 ),
-                validator: (value) {
-                  if (value == null || value.trim().isEmpty) {
-                    return 'Course content is required';
-                  }
-                  return null;
-                },
               ),
+              const SizedBox(height: 12),
+              Obx(() {
+                final mode = controller.contentInputMode.value;
+                final isExtracting = controller.isExtractingContent.value;
+                final source = controller.lastContentSource.value;
+                final error = controller.extractionError.value;
+                return Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        ChoiceChip(
+                          label: const Text('Write text'),
+                          selected: mode == CourseContentInputMode.manual,
+                          onSelected: (selected) {
+                            if (selected) {
+                              controller
+                                  .setContentInputMode(CourseContentInputMode.manual);
+                            }
+                          },
+                        ),
+                        ChoiceChip(
+                          label: const Text('Upload PDF'),
+                          selected: mode == CourseContentInputMode.pdf,
+                          onSelected: (selected) {
+                            if (selected) {
+                              controller
+                                  .setContentInputMode(CourseContentInputMode.pdf);
+                            }
+                          },
+                        ),
+                        ChoiceChip(
+                          label: const Text('Use image'),
+                          selected: mode == CourseContentInputMode.image,
+                          onSelected: (selected) {
+                            if (selected) {
+                              controller
+                                  .setContentInputMode(CourseContentInputMode.image);
+                            }
+                          },
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    if (mode == CourseContentInputMode.manual)
+                      Text(
+                        'Type the course content in the field below.',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                    if (mode == CourseContentInputMode.pdf) ...[
+                      Text(
+                        'Upload a PDF to extract its text into the content field.',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 8),
+                      OutlinedButton.icon(
+                        onPressed:
+                            isExtracting ? null : controller.pickPdfAndExtractText,
+                        icon: const Icon(Icons.picture_as_pdf_outlined),
+                        label: Text(
+                          isExtracting ? 'Extracting…' : 'Select PDF',
+                        ),
+                      ),
+                    ],
+                    if (mode == CourseContentInputMode.image) ...[
+                      Text(
+                        'Capture or select an image containing the course text.',
+                        style: theme.textTheme.bodySmall,
+                      ),
+                      const SizedBox(height: 8),
+                      Row(
+                        children: [
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: isExtracting
+                                  ? null
+                                  : () => controller.pickImageAndExtractText(
+                                        fromCamera: true,
+                                      ),
+                              icon: const Icon(Icons.photo_camera_outlined),
+                              label: Text(
+                                isExtracting ? 'Processing…' : 'Use camera',
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: OutlinedButton.icon(
+                              onPressed: isExtracting
+                                  ? null
+                                  : () => controller.pickImageAndExtractText(
+                                        fromCamera: false,
+                                      ),
+                              icon: const Icon(Icons.image_outlined),
+                              label: Text(
+                                isExtracting ? 'Processing…' : 'Upload image',
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                    if (isExtracting) ...[
+                      const SizedBox(height: 12),
+                      const LinearProgressIndicator(),
+                    ],
+                    if (source != null) ...[
+                      const SizedBox(height: 12),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.primary.withOpacity(0.08),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          source,
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ),
+                    ],
+                    if (error != null) ...[
+                      const SizedBox(height: 12),
+                      Container(
+                        width: double.infinity,
+                        padding: const EdgeInsets.all(12),
+                        decoration: BoxDecoration(
+                          color: theme.colorScheme.error.withOpacity(0.08),
+                          borderRadius: BorderRadius.circular(12),
+                        ),
+                        child: Text(
+                          error,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.error,
+                          ),
+                        ),
+                      ),
+                    ],
+                    const SizedBox(height: 12),
+                    TextFormField(
+                      controller: controller.contentController,
+                      minLines: 5,
+                      maxLines: 10,
+                      enabled: !isExtracting,
+                      decoration: InputDecoration(
+                        labelText: 'Content',
+                        border: const OutlineInputBorder(),
+                        alignLabelWithHint: true,
+                        hintText:
+                            mode == CourseContentInputMode.manual
+                                ? 'Add the detailed course content here... This will be available in the PDF download.'
+                                : 'Extracted text will appear here. You can review and edit it before saving.',
+                      ),
+                      validator: (value) {
+                        if (value == null || value.trim().isEmpty) {
+                          return 'Course content is required';
+                        }
+                        return null;
+                      },
+                    ),
+                  ],
+                );
+              }),
               const SizedBox(height: 24),
               Text(
                 'Assign to classes',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,6 +23,10 @@ dependencies:
   intl: ^0.19.0
   pdf: ^3.11.0
   printing: ^5.13.4
+  file_picker: ^8.1.2
+  pdf_text: ^1.0.2
+  image_picker: ^1.0.7
+  google_mlkit_text_recognition: ^0.13.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add dependencies required for picking files/images and running text recognition
- extend the teacher course controller to support manual entry, PDF extraction, and image OCR when preparing course content
- update the course form to let teachers choose their content source and review extraction status before saving

## Testing
- Not run (Flutter SDK not available in the environment)


------
https://chatgpt.com/codex/tasks/task_e_68cc8afbcbc0833182d6f8a2d40f740e