### PR TITLE
Fix announcement persistence and navigation

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -100,8 +100,12 @@ class DatabaseService extends GetxService {
 
   /// Announcement CRUD operations
   Future<String> addAnnouncement(AnnouncementModel announcement) async {
-    final doc = await _firestore.collection('announcements').add(announcement.toMap());
-    return doc.id;
+    final docRef = _firestore.collection('announcements').doc();
+    final payload = announcement
+        .copyWith(id: docRef.id, createdAt: DateTime.now())
+        .toMap(includeId: true, serverTimestamp: true);
+    await docRef.set(payload);
+    return docRef.id;
   }
 
   Future<void> updateAnnouncement(AnnouncementModel announcement) async {

--- a/lib/data/models/announcement_model.dart
+++ b/lib/data/models/announcement_model.dart
@@ -26,12 +26,34 @@ class AnnouncementModel {
     );
   }
 
-  Map<String, dynamic> toMap() {
-    return {
+  AnnouncementModel copyWith({
+    String? id,
+    String? title,
+    String? description,
+    List<String>? audience,
+    DateTime? createdAt,
+  }) {
+    return AnnouncementModel(
+      id: id ?? this.id,
+      title: title ?? this.title,
+      description: description ?? this.description,
+      audience: audience ?? List<String>.from(this.audience),
+      createdAt: createdAt ?? this.createdAt,
+    );
+  }
+
+  Map<String, dynamic> toMap({bool includeId = false, bool serverTimestamp = false}) {
+    final map = <String, dynamic>{
       'title': title,
       'description': description,
       'audience': audience,
-      'createdAt': Timestamp.fromDate(createdAt),
+      'createdAt': serverTimestamp
+          ? FieldValue.serverTimestamp()
+          : Timestamp.fromDate(createdAt),
     };
+    if (includeId) {
+      map['id'] = id;
+    }
+    return map;
   }
 }

--- a/lib/modules/announcement/views/announcement_list_view.dart
+++ b/lib/modules/announcement/views/announcement_list_view.dart
@@ -16,8 +16,12 @@ class AnnouncementListView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final controller =
-        Get.put(AnnouncementController(audienceFilter: audience));
+    final controller = Get.put(
+      AnnouncementController(
+        audienceFilter: audience,
+        isAdminView: isAdmin,
+      ),
+    );
     final theme = Theme.of(context);
     return Scaffold(
       backgroundColor: theme.colorScheme.surface,


### PR DESCRIPTION
## Summary
- ensure announcements are saved with a generated document id and server timestamp
- add list-route awareness so the form returns to the appropriate announcement list after saving

## Testing
- not run (flutter is not available in the container)


------
https://chatgpt.com/codex/tasks/task_e_68cc8dd2d8588331a71a6ac94ae05fcd