### PR TITLE
Replace file picker dependency with file selector

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -169,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.1"
-  file_picker:
-    dependency: "direct main"
-    description:
-      name: file_picker
-      sha256: f2d9f173c2c14635cc0e9b14c143c49ef30b4934e8d1d274d6206fcb0086a06f
-      url: "https://pub.dev"
-    source: hosted
-    version: "10.3.3"
   file_selector_linux:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,10 +23,11 @@ dependencies:
   intl: ^0.19.0
   pdf: ^3.11.0
   printing: ^5.13.4
-  file_picker: ^10.3.3
+  file_selector: ^1.0.3
   pdf_text: ^0.5.0
   image_picker: ^1.2.0
   google_mlkit_text_recognition: ^0.15.0
+  path_provider: ^2.1.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- switch the app from the third-party `file_picker` package to Flutter's `file_selector` plus `path_provider`
- update the teacher courses controller to select PDFs through `file_selector` and persist a temporary copy when no local path is available

## Testing
- not run (Flutter SDK is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68cc9974fd308331848db5a9833ed219