### PR TITLE
Simplify teacher course creation and remove pdf_text

### DIFF
--- a/lib/modules/courses/views/course_form_view.dart
+++ b/lib/modules/courses/views/course_form_view.dart
@@ -11,7 +11,6 @@ class CourseFormView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final subjectName = controller.subject.value?.name ?? 'Subject not set';
     return Scaffold(
       appBar: AppBar(
         title: Text(controller.editing == null ? 'Add Course' : 'Edit Course'),
@@ -24,43 +23,17 @@ class CourseFormView extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Card(
-                elevation: 0,
-                color: theme.colorScheme.primary.withOpacity(0.08),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(16),
+              Text(
+                'Course details',
+                style: theme.textTheme.titleLarge?.copyWith(
+                  fontWeight: FontWeight.w700,
                 ),
-                child: Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Row(
-                    children: [
-                      Icon(
-                        Icons.menu_book_outlined,
-                        color: theme.colorScheme.primary,
-                      ),
-                      const SizedBox(width: 12),
-                      Expanded(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Text(
-                              'Subject',
-                              style: theme.textTheme.labelMedium?.copyWith(
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                            ),
-                            const SizedBox(height: 4),
-                            Text(
-                              subjectName,
-                              style: theme.textTheme.titleMedium?.copyWith(
-                                fontWeight: FontWeight.w600,
-                              ),
-                            ),
-                          ],
-                        ),
-                      ),
-                    ],
-                  ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                'Provide a clear title, a short description, and the lesson content below.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
                 ),
               ),
               const SizedBox(height: 24),
@@ -131,47 +104,6 @@ class CourseFormView extends StatelessWidget {
                   ),
                 ],
               ),
-              const SizedBox(height: 24),
-              Text(
-                'Assign to classes',
-                style: theme.textTheme.titleMedium?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              const SizedBox(height: 12),
-              Obx(() {
-                if (controller.availableClasses.isEmpty) {
-                  return Container(
-                    width: double.infinity,
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      borderRadius: BorderRadius.circular(12),
-                      color: theme.colorScheme.error.withOpacity(0.08),
-                    ),
-                    child: Text(
-                      'No classes are linked to your subject yet. Contact the administrator.',
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.error,
-                      ),
-                    ),
-                  );
-                }
-                return Wrap(
-                  spacing: 8,
-                  runSpacing: 8,
-                  children: controller.availableClasses
-                      .map(
-                        (schoolClass) => FilterChip(
-                          label: Text(schoolClass.name),
-                          selected: controller.selectedClassIds
-                              .contains(schoolClass.id),
-                          onSelected: (_) =>
-                              controller.toggleClassSelection(schoolClass.id),
-                        ),
-                      )
-                      .toList(),
-                );
-              }),
               const SizedBox(height: 32),
               Obx(() {
                 final saving = controller.isSaving.value;

--- a/lib/modules/courses/views/teacher_courses_view.dart
+++ b/lib/modules/courses/views/teacher_courses_view.dart
@@ -36,7 +36,6 @@ class TeacherCoursesView extends StatelessWidget {
           ),
           child: Column(
             children: [
-              _buildFilters(context),
               Expanded(
                 child: controller.courses.isEmpty
                     ? _buildEmptyState(context)
@@ -70,17 +69,14 @@ class TeacherCoursesView extends StatelessWidget {
               ),
             ],
           ),
-        );
-      }),
-      floatingActionButton: Obx(() {
-        final hasClasses = controller.availableClasses.isNotEmpty;
-        return FloatingActionButton.extended(
-          heroTag: 'teacherCoursesFab',
-          onPressed: hasClasses ? () => controller.openForm() : null,
-          icon: const Icon(Icons.add),
-          label: Text(hasClasses ? 'New Course' : 'No classes available'),
-        );
-      }),
+      );
+    }),
+      floatingActionButton: FloatingActionButton.extended(
+        heroTag: 'teacherCoursesFab',
+        onPressed: controller.openForm,
+        icon: const Icon(Icons.add),
+        label: const Text('New Course'),
+      ),
     );
   }
 
@@ -122,113 +118,6 @@ class TeacherCoursesView extends StatelessWidget {
             ),
           ],
         ),
-      ),
-    );
-  }
-
-  Widget _buildFilters(BuildContext context) {
-    final theme = Theme.of(context);
-    return Padding(
-      padding: const EdgeInsets.fromLTRB(16, 20, 16, 8),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Text(
-                'Filter courses',
-                style: theme.textTheme.titleSmall?.copyWith(
-                  fontWeight: FontWeight.w600,
-                ),
-              ),
-              Obx(() {
-                final hasFilter =
-                    controller.selectedFilterClassId.value.isNotEmpty;
-                return TextButton.icon(
-                  onPressed: hasFilter ? controller.clearFilters : null,
-                  icon: const Icon(Icons.filter_alt_off_outlined, size: 18),
-                  label: const Text('Clear'),
-                );
-              }),
-            ],
-          ),
-          const SizedBox(height: 12),
-          Obx(() {
-            final selectedId = controller.selectedFilterClassId.value;
-            if (selectedId.isEmpty) {
-              return const SizedBox.shrink();
-            }
-            return Padding(
-              padding: const EdgeInsets.only(bottom: 12),
-              child: Wrap(
-                spacing: 8,
-                runSpacing: 8,
-                children: [
-                  _buildActiveFilterChip(
-                    context,
-                    label: 'Class: ${controller.className(selectedId)}',
-                    onRemoved: () => controller.updateClassFilter(''),
-                  ),
-                ],
-              ),
-            );
-          }),
-          Obx(() {
-            final classes = controller.availableClasses;
-            return DropdownButtonFormField<String>(
-              value: controller.selectedFilterClassId.value.isEmpty
-                  ? null
-                  : controller.selectedFilterClassId.value,
-              decoration: const InputDecoration(
-                labelText: 'Class',
-                border: OutlineInputBorder(),
-              ),
-              hint: Text(
-                classes.isNotEmpty ? 'All classes' : 'No classes available',
-              ),
-              items: [
-                const DropdownMenuItem<String>(
-                  value: '',
-                  child: Text('All classes'),
-                ),
-                ...classes
-                    .map(
-                      (schoolClass) => DropdownMenuItem<String>(
-                        value: schoolClass.id,
-                        child: Text(schoolClass.name),
-                      ),
-                    )
-                    .toList(),
-              ],
-              onChanged: (value) => controller.updateClassFilter(value ?? ''),
-            );
-          }),
-        ],
-      ),
-    );
-  }
-
-  Widget _buildActiveFilterChip(
-    BuildContext context, {
-    required String label,
-    required VoidCallback onRemoved,
-  }) {
-    final theme = Theme.of(context);
-    return Chip(
-      avatar: Icon(
-        Icons.filter_alt_outlined,
-        size: 18,
-        color: theme.colorScheme.primary,
-      ),
-      label: Text(label),
-      deleteIcon: const Icon(Icons.close, size: 18),
-      onDeleted: onRemoved,
-      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-      labelStyle: theme.textTheme.bodySmall?.copyWith(
-        color: theme.colorScheme.primary,
-        fontWeight: FontWeight.w600,
       ),
     );
   }
@@ -303,9 +192,9 @@ class _CourseListTile extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final classes = course.classNames.isEmpty
-        ? 'No class assigned'
-        : course.classNames.join(', ');
+    final descriptionPreview = course.description.isEmpty
+        ? 'Tap to view the course details.'
+        : course.description;
     return Material(
       color: Colors.transparent,
       child: InkWell(
@@ -335,23 +224,13 @@ class _CourseListTile extends StatelessWidget {
                   ),
                 ),
                 const SizedBox(height: 8),
-                Row(
-                  children: [
-                    Icon(
-                      Icons.group_outlined,
-                      size: 18,
-                      color: theme.colorScheme.primary,
-                    ),
-                    const SizedBox(width: 6),
-                    Expanded(
-                      child: Text(
-                        classes,
-                        style: theme.textTheme.bodyMedium?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ),
-                  ],
+                Text(
+                  descriptionPreview,
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
                 ),
               ],
             ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -552,14 +552,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.11.3"
-  pdf_text:
-    dependency: "direct main"
-    description:
-      name: pdf_text
-      sha256: ea906fbc95c3c13bf91be826daaec5524182db0a0bfa5eae702f78e8dd1d26c8
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.0"
   pdf_widget_wrapper:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,6 @@ dependencies:
   pdf: ^3.11.0
   printing: ^5.13.4
   file_selector: ^1.0.3
-  pdf_text: ^0.5.0
   image_picker: ^1.2.0
   google_mlkit_text_recognition: ^0.15.0
   path_provider: ^2.1.5


### PR DESCRIPTION
## Summary
- remove the unused pdf_text dependency that was breaking Android builds
- streamline the teacher course workflow so teachers only provide title, description, and content
- simplify the teacher course list UI by dropping class filters and showing a description preview

## Testing
- flutter test *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc9fe0334883319eec363a252e9c10