### PR TITLE
Fix announcement flow and audience streaming

### DIFF
--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -117,11 +117,12 @@ class DatabaseService extends GetxService {
     if (audience != null) {
       query = query.where('audience', arrayContains: audience);
     }
-    return query
-        .orderBy('createdAt', descending: true)
-        .snapshots()
-        .map((snapshot) =>
-            snapshot.docs.map((doc) => AnnouncementModel.fromDoc(doc)).toList());
+    return query.snapshots().map((snapshot) {
+      final items =
+          snapshot.docs.map((doc) => AnnouncementModel.fromDoc(doc)).toList();
+      items.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+      return items;
+    });
   }
 
   /// Course CRUD operations

--- a/lib/modules/announcement/controllers/announcement_controller.dart
+++ b/lib/modules/announcement/controllers/announcement_controller.dart
@@ -41,6 +41,7 @@ class AnnouncementController extends GetxController {
           valid.add(ann);
         }
       }
+      valid.sort((a, b) => b.createdAt.compareTo(a.createdAt));
       announcements.value = valid;
     });
   }
@@ -92,24 +93,25 @@ class AnnouncementController extends GetxController {
         audience: audience,
         createdAt: editing?.createdAt ?? DateTime.now(),
       );
-      if (editing == null) {
-        await _db.addAnnouncement(announcement);
-        Get.snackbar(
-          'Announcement published',
-          'Your announcement is now visible to the selected audience.',
-          snackPosition: SnackPosition.BOTTOM,
-        );
-      } else {
+      final isEditingExisting = editing != null;
+
+      if (isEditingExisting) {
         await _db.updateAnnouncement(announcement);
-        Get.snackbar(
-          'Announcement updated',
-          'Changes have been saved successfully.',
-          snackPosition: SnackPosition.BOTTOM,
-        );
+      } else {
+        await _db.addAnnouncement(announcement);
       }
-      Get.back();
-      editing = null;
+
       clearForm();
+      editing = null;
+
+      Get.back();
+      Get.snackbar(
+        isEditingExisting ? 'Announcement updated' : 'Announcement published',
+        isEditingExisting
+            ? 'Changes have been saved successfully.'
+            : 'Your announcement is now visible to the selected audience.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
     } catch (e) {
       Get.snackbar(
         'Error',


### PR DESCRIPTION
## Summary
- ensure announcements are streamed without requiring Firestore composite indexes by sorting client-side
- keep admin list ordered after filtering expired announcements
- navigate back to the announcement list before showing success messages when saving

## Testing
- `flutter analyze` *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1ae4e11f483319b865c81e381c976