### PR TITLE
Implement direct PDF downloads and adjust announcement UI

### DIFF
--- a/lib/core/services/pdf_downloader/pdf_downloader.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader.dart
@@ -1,0 +1,14 @@
+import 'dart:typed_data';
+
+import 'pdf_downloader_stub.dart'
+    if (dart.library.html) 'pdf_downloader_web.dart'
+    if (dart.library.io) 'pdf_downloader_io.dart' as downloader;
+
+/// Saves a PDF to an appropriate download location for the current platform.
+///
+/// Returns the path of the saved file when it can be determined (mainly on
+/// IO-based platforms). Web platforms trigger a browser download and return
+/// `null` because no local file path is available.
+Future<String?> savePdf(Uint8List bytes, String fileName) {
+  return downloader.savePdf(bytes, fileName);
+}

--- a/lib/core/services/pdf_downloader/pdf_downloader_io.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_io.dart
@@ -1,0 +1,48 @@
+import 'dart:io';
+import 'dart:typed_data';
+
+Future<String?> savePdf(Uint8List bytes, String fileName) async {
+  final directory = await _resolveDownloadDirectory();
+  final sanitizedName = fileName.trim().isEmpty ? 'document.pdf' : fileName;
+  final file = File('${directory.path}/$sanitizedName');
+  await file.writeAsBytes(bytes, flush: true);
+  return file.path;
+}
+
+Future<Directory> _resolveDownloadDirectory() async {
+  if (Platform.isAndroid) {
+    const potentialPaths = [
+      '/storage/emulated/0/Download',
+      '/sdcard/Download',
+    ];
+
+    for (final path in potentialPaths) {
+      final directory = Directory(path);
+      if (await directory.exists()) {
+        return directory;
+      }
+    }
+  } else if (Platform.isMacOS || Platform.isLinux) {
+    final home = Platform.environment['HOME'];
+    if (home != null) {
+      final downloads = Directory('$home/Downloads');
+      if (await downloads.exists()) {
+        return downloads;
+      }
+    }
+  } else if (Platform.isWindows) {
+    final profile = Platform.environment['USERPROFILE'];
+    if (profile != null) {
+      final downloads = Directory('$profile/Downloads');
+      if (await downloads.exists()) {
+        return downloads;
+      }
+    }
+  }
+
+  final fallback = Directory('${Directory.systemTemp.path}/edums-downloads');
+  if (!await fallback.exists()) {
+    await fallback.create(recursive: true);
+  }
+  return fallback;
+}

--- a/lib/core/services/pdf_downloader/pdf_downloader_stub.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_stub.dart
@@ -1,0 +1,5 @@
+import 'dart:typed_data';
+
+Future<String?> savePdf(Uint8List bytes, String fileName) async {
+  throw UnsupportedError('PDF downloading is not supported on this platform');
+}

--- a/lib/core/services/pdf_downloader/pdf_downloader_web.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_web.dart
@@ -1,0 +1,19 @@
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html;
+import 'dart:typed_data';
+
+Future<String?> savePdf(Uint8List bytes, String fileName) async {
+  final sanitizedName = fileName.trim().isEmpty ? 'document.pdf' : fileName;
+  final blob = html.Blob([bytes], 'application/pdf');
+  final url = html.Url.createObjectUrlFromBlob(blob);
+  final anchor = html.AnchorElement(href: url)
+    ..style.display = 'none'
+    ..download = sanitizedName;
+
+  html.document.body?.children.add(anchor);
+  anchor.click();
+  anchor.remove();
+  html.Url.revokeObjectUrl(url);
+
+  return null;
+}

--- a/lib/modules/courses/views/course_detail_view.dart
+++ b/lib/modules/courses/views/course_detail_view.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 import 'package:pdf/widgets.dart' as pw;
-import 'package:printing/printing.dart';
+
+import 'package:edums/core/services/pdf_downloader/pdf_downloader.dart';
 
 import '../../../data/models/course_model.dart';
 
@@ -346,11 +347,17 @@ class CourseDetailView extends StatelessWidget {
     try {
       final bytes = await doc.save();
       final fileName = _pdfFileName();
-      await Printing.sharePdf(
-        bytes: bytes,
-        filename: fileName,
+      final savedPath = await savePdf(bytes, fileName);
+      Get.closeCurrentSnackbar();
+      Get.snackbar(
+        'Download complete',
+        savedPath != null
+            ? 'Saved to $savedPath'
+            : 'The PDF download has started.',
+        snackPosition: SnackPosition.BOTTOM,
       );
     } catch (e) {
+      Get.closeCurrentSnackbar();
       Get.snackbar(
         'Error',
         'Failed to generate the PDF. ${e.toString()}',


### PR DESCRIPTION
## Summary
- add a platform-aware PDF downloader service to store generated documents directly without invoking the share sheet
- update course and announcement detail PDF generators to use the downloader and improve the completion messaging
- hide announcement expiration chips and badges when viewing the detail screen as a non-admin user

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d1b195b63c83319bfbf4ea200a9655