### PR TITLE
feat: separate admin attendance flows and improve teacher UI

### DIFF
--- a/lib/app/bindings/app-binding.dart
+++ b/lib/app/bindings/app-binding.dart
@@ -6,6 +6,7 @@ import '../../core/services/database_service.dart';
 import '../../modules/admin_dashboard/controllers/admin_controller.dart';
 import '../../modules/admin_dashboard/controllers/admin_control_controller.dart';
 import '../../modules/attendance/controllers/admin_attendance_controller.dart';
+import '../../modules/attendance/controllers/admin_teacher_attendance_controller.dart';
 import '../../modules/attendance/controllers/parent_attendance_controller.dart';
 import '../../modules/attendance/controllers/teacher_attendance_controller.dart';
 import '../../modules/auth/controllers/auth_controller.dart';
@@ -51,6 +52,7 @@ class AppBindings extends Bindings {
     Get.lazyPut(() => AdminController(), fenix: true);
     Get.lazyPut(() => AdminControlController(), fenix: true);
     Get.lazyPut(() => AdminAttendanceController(), fenix: true);
+    Get.lazyPut(() => AdminTeacherAttendanceController(), fenix: true);
     Get.lazyPut(() => AdminBehaviorController(), fenix: true);
     Get.lazyPut(() => AdminHomeworkController(), fenix: true);
     Get.lazyPut(() => AdminPickupController(), fenix: true);

--- a/lib/app/routes/app_pages.dart
+++ b/lib/app/routes/app_pages.dart
@@ -5,6 +5,7 @@ import '../../modules/admin_dashboard/views/admin_control_view.dart';
 import '../../modules/admin_dashboard/views/admin_dashboard_view.dart';
 import '../../modules/announcement/views/announcement_list_view.dart';
 import '../../modules/attendance/views/admin_attendance_view.dart';
+import '../../modules/attendance/views/admin_teacher_attendance_view.dart';
 import '../../modules/attendance/views/parent_attendance_view.dart';
 import '../../modules/attendance/views/teacher_attendance_view.dart';
 import '../../modules/auth/views/login_view.dart';
@@ -41,6 +42,7 @@ abstract class AppPages {
   static const TEACHER_HOMEWORK = '/teacher/homework';
   static const PARENT_HOMEWORK = '/parent/homework';
   static const ADMIN_ATTENDANCE = '/admin/attendance';
+  static const ADMIN_TEACHER_ATTENDANCE = '/admin/attendance/teachers';
   static const TEACHER_ATTENDANCE = '/teacher/attendance';
   static const PARENT_ATTENDANCE = '/parent/attendance';
   static const ADMIN_BEHAVIOR = '/admin/behavior';
@@ -77,6 +79,9 @@ abstract class AppPages {
         name: TEACHER_HOMEWORK, page: () => const TeacherHomeworkListView()),
     GetPage(name: PARENT_HOMEWORK, page: () => const ParentHomeworkListView()),
     GetPage(name: ADMIN_ATTENDANCE, page: () => const AdminAttendanceView()),
+    GetPage(
+        name: ADMIN_TEACHER_ATTENDANCE,
+        page: () => const AdminTeacherAttendanceView()),
     GetPage(
         name: TEACHER_ATTENDANCE, page: () => const TeacherAttendanceView()),
     GetPage(

--- a/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
+++ b/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
@@ -38,10 +38,17 @@ class AdminDashboard extends StatelessWidget {
         ),
         DashboardCard(
           icon: Icons.calendar_today,
-          title: 'Attendance',
-          subtitle: 'Student presence',
+          title: 'Student Attendance',
+          subtitle: 'Track classroom presence',
           color: Colors.orange,
           onTap: () => Get.toNamed(AppPages.ADMIN_ATTENDANCE),
+        ),
+        DashboardCard(
+          icon: Icons.fact_check_outlined,
+          title: 'Teacher Attendance',
+          subtitle: 'Monitor staff check-ins',
+          color: Colors.deepOrange,
+          onTap: () => Get.toNamed(AppPages.ADMIN_TEACHER_ATTENDANCE),
         ),
         DashboardCard(
           icon: Icons.emoji_people,

--- a/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
@@ -1,0 +1,265 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:collection/collection.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
+
+import '../../../core/services/database_service.dart';
+import '../../../core/services/pdf_downloader/pdf_downloader.dart';
+import '../../../data/models/attendance_record_model.dart';
+import '../../../data/models/teacher_model.dart';
+
+class AdminTeacherAttendanceController extends GetxController {
+  final DatabaseService _db = Get.find();
+
+  StreamSubscription? _teachersSubscription;
+  StreamSubscription? _attendanceSubscription;
+
+  final RxBool isLoading = true.obs;
+  final RxBool isSaving = false.obs;
+  final RxBool isExporting = false.obs;
+
+  final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
+  final RxList<TeacherAttendanceRecord> _records = <TeacherAttendanceRecord>[].obs;
+  final RxList<TeacherAttendanceRecord> currentEntries = <TeacherAttendanceRecord>[].obs;
+
+  final Rx<DateTime> selectedDate = DateTime.now().obs;
+
+  bool _teachersLoaded = false;
+  bool _attendanceLoaded = false;
+
+  @override
+  void onInit() {
+    super.onInit();
+    _initialize();
+  }
+
+  @override
+  void onClose() {
+    _teachersSubscription?.cancel();
+    _attendanceSubscription?.cancel();
+    super.onClose();
+  }
+
+  void setDate(DateTime date) {
+    selectedDate.value = DateTime(date.year, date.month, date.day);
+    _rebuildEntries();
+  }
+
+  void toggleStatus(String teacherId) {
+    final index = currentEntries.indexWhere((entry) => entry.teacherId == teacherId);
+    if (index == -1) {
+      return;
+    }
+    final entry = currentEntries[index];
+    final updated = entry.copyWith(
+      status: entry.status == AttendanceStatus.present
+          ? AttendanceStatus.absent
+          : AttendanceStatus.present,
+    );
+    currentEntries[index] = updated;
+  }
+
+  Future<void> saveAttendance() async {
+    if (currentEntries.isEmpty) {
+      Get.snackbar(
+        'No teachers found',
+        'There are no teachers to mark on this date.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+    isSaving.value = true;
+    try {
+      final batch = _db.firestore.batch();
+      final day = selectedDate.value;
+      for (final entry in currentEntries) {
+        final normalized = entry.copyWith(date: day);
+        final docRef =
+            _db.firestore.collection('teacherAttendanceRecords').doc(normalized.id);
+        batch.set(docRef, normalized.toMap());
+      }
+      await batch.commit();
+      Get.snackbar(
+        'Attendance saved',
+        'Teacher attendance has been recorded.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } catch (error) {
+      Get.snackbar(
+        'Save failed',
+        'Unable to store attendance: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isSaving.value = false;
+    }
+  }
+
+  Future<void> exportAttendanceAsPdf() async {
+    final entries = currentEntries;
+    if (entries.isEmpty) {
+      Get.snackbar(
+        'Nothing to export',
+        'Add at least one teacher attendance record before exporting.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+    isExporting.value = true;
+    try {
+      final dateLabel = DateFormat.yMMMMd().format(selectedDate.value);
+      final doc = pw.Document();
+      final tableData = entries
+          .map(
+            (entry) => [
+              entry.teacherName,
+              entry.status.label,
+              entry.note.isEmpty ? '-' : entry.note,
+            ],
+          )
+          .toList();
+
+      doc.addPage(
+        pw.MultiPage(
+          build: (pw.Context context) => [
+            pw.Header(
+              level: 0,
+              child: pw.Text(
+                'Teacher Attendance – $dateLabel',
+                style: pw.TextStyle(
+                  fontSize: 22,
+                  fontWeight: pw.FontWeight.bold,
+                ),
+              ),
+            ),
+            pw.SizedBox(height: 12),
+            pw.Table.fromTextArray(
+              headers: const ['Teacher', 'Status', 'Note'],
+              data: tableData,
+              headerStyle: pw.TextStyle(
+                fontWeight: pw.FontWeight.bold,
+                color: PdfColors.black,
+              ),
+              headerDecoration: const pw.BoxDecoration(
+                color: PdfColors.grey300,
+              ),
+              cellStyle: const pw.TextStyle(fontSize: 11),
+              cellAlignment: pw.Alignment.centerLeft,
+              columnWidths: {
+                0: const pw.FlexColumnWidth(2.5),
+                1: const pw.FlexColumnWidth(1),
+                2: const pw.FlexColumnWidth(2),
+              },
+            ),
+          ],
+        ),
+      );
+
+      final fileName =
+          'teacher-attendance-${DateFormat('yyyyMMdd').format(selectedDate.value)}.pdf';
+      final bytes = await doc.save();
+      final savedPath = await savePdf(bytes, fileName);
+      Get.closeCurrentSnackbar();
+      Get.snackbar(
+        'Download complete',
+        savedPath != null
+            ? 'Saved to $savedPath'
+            : 'The PDF download has started.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } catch (error) {
+      Get.snackbar(
+        'Export failed',
+        'Unable to create the PDF: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      isExporting.value = false;
+    }
+  }
+
+  void _initialize() {
+    try {
+      _teachersSubscription = _db.firestore
+          .collection('teachers')
+          .snapshots()
+          .listen((snapshot) {
+        final items = snapshot.docs.map(TeacherModel.fromDoc).toList()
+          ..sort((a, b) => a.name.compareTo(b.name));
+        teachers.assignAll(items);
+        _teachersLoaded = true;
+        _rebuildEntries();
+        _maybeFinishLoading();
+      });
+
+      _attendanceSubscription = _db.firestore
+          .collection('teacherAttendanceRecords')
+          .snapshots()
+          .listen((snapshot) {
+        _records.assignAll(
+          snapshot.docs.map(TeacherAttendanceRecord.fromDoc).toList(),
+        );
+        _attendanceLoaded = true;
+        _rebuildEntries();
+        _maybeFinishLoading();
+      });
+    } catch (error) {
+      isLoading.value = false;
+      Get.snackbar(
+        'Load failed',
+        'Unable to load teacher attendance data: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+
+  void _rebuildEntries() {
+    if (teachers.isEmpty) {
+      currentEntries.clear();
+      return;
+    }
+    final day = selectedDate.value;
+    final dayRecords = _records
+        .where((record) => _isSameDay(record.date, day))
+        .toList();
+
+    final entries = teachers.map((teacher) {
+      final existing =
+          dayRecords.firstWhereOrNull((record) => record.teacherId == teacher.id);
+      if (existing != null) {
+        return existing.copyWith(
+          date: DateTime(day.year, day.month, day.day),
+        );
+      }
+      return TeacherAttendanceRecord(
+        id: _composeRecordId(teacher.id, day),
+        teacherId: teacher.id,
+        teacherName: teacher.name,
+        date: DateTime(day.year, day.month, day.day),
+        status: AttendanceStatus.absent,
+        note: '',
+      );
+    }).toList();
+
+    currentEntries.assignAll(entries);
+  }
+
+  void _maybeFinishLoading() {
+    if (_teachersLoaded && _attendanceLoaded) {
+      isLoading.value = false;
+    }
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _composeRecordId(String teacherId, DateTime date) {
+    final safeDate = DateFormat('yyyyMMdd').format(date);
+    return '$teacherId-$safeDate';
+  }
+}

--- a/lib/modules/attendance/views/admin_attendance_view.dart
+++ b/lib/modules/attendance/views/admin_attendance_view.dart
@@ -14,152 +14,74 @@ class AdminAttendanceView extends GetView<AdminAttendanceController> {
   @override
   Widget build(BuildContext context) {
     final dateFormat = DateFormat.yMMMMd();
-    return DefaultTabController(
-      length: 2,
-      child: Scaffold(
-        appBar: AppBar(
-          title: const Text('Attendance Monitoring'),
-          centerTitle: true,
-          bottom: const TabBar(
-            tabs: [
-              Tab(text: 'Children'),
-              Tab(text: 'Teachers'),
-            ],
-          ),
-        ),
-        body: ModulePageContainer(
-          child: Column(
-            children: [
-              const _AdminAttendanceFilters(),
-              Expanded(
-                child: TabBarView(
-                  children: [
-                    Obx(() {
-                      final sessions = controller.classSessions;
-                      if (sessions.isEmpty) {
-                        return ListView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                          children: const [
-                            ModuleEmptyState(
-                              icon: Icons.school_outlined,
-                              title: 'No child attendance records',
-                              message:
-                                  'Adjust the filters above to review attendance submissions for specific classes.',
-                            ),
-                          ],
-                        );
-                      }
-                      return ListView.separated(
-                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                        physics: const BouncingScrollPhysics(),
-                        itemCount: sessions.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 16),
-                        itemBuilder: (context, index) {
-                          final session = sessions[index];
-                          final presentCount = session.records
-                              .where((record) => record.status == AttendanceStatus.present)
-                              .length;
-                          return ModuleCard(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  '${session.className} • ${session.teacherName}',
-                                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                        fontWeight: FontWeight.w700,
-                                      ),
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Student Attendance'),
+        centerTitle: true,
+      ),
+      body: ModulePageContainer(
+        child: Column(
+          children: [
+            const _AdminAttendanceFilters(),
+            Expanded(
+              child: Obx(() {
+                final sessions = controller.classSessions;
+                if (sessions.isEmpty) {
+                  return ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                    children: const [
+                      ModuleEmptyState(
+                        icon: Icons.school_outlined,
+                        title: 'No student attendance records',
+                        message:
+                            'Adjust the filters above to review attendance submissions for specific classes.',
+                      ),
+                    ],
+                  );
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                  physics: const BouncingScrollPhysics(),
+                  itemCount: sessions.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 16),
+                  itemBuilder: (context, index) {
+                    final session = sessions[index];
+                    final presentCount = session.records
+                        .where((record) => record.status == AttendanceStatus.present)
+                        .length;
+                    return ModuleCard(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            '${session.className} • ${session.teacherName}',
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                                  fontWeight: FontWeight.w700,
                                 ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  dateFormat.format(session.date),
-                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                                      ),
+                          ),
+                          const SizedBox(height: 8),
+                          Text(
+                            dateFormat.format(session.date),
+                            style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
                                 ),
-                                const SizedBox(height: 12),
-                                Text(
-                                  '$presentCount/${session.records.length} present',
-                                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                        fontWeight: FontWeight.w600,
-                                      ),
+                          ),
+                          const SizedBox(height: 12),
+                          Text(
+                            '$presentCount/${session.records.length} present',
+                            style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                                  fontWeight: FontWeight.w600,
                                 ),
-                              ],
-                            ),
-                          );
-                        },
-                      );
-                    }),
-                    Obx(() {
-                      final records = controller.teacherRecords;
-                      if (records.isEmpty) {
-                        return ListView(
-                          physics: const AlwaysScrollableScrollPhysics(),
-                          padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                          children: const [
-                            ModuleEmptyState(
-                              icon: Icons.person_outline,
-                              title: 'No teacher attendance records',
-                              message:
-                                  'Use the filters above to explore teacher attendance submissions.',
-                            ),
-                          ],
-                        );
-                      }
-                      return ListView.separated(
-                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                        physics: const BouncingScrollPhysics(),
-                        itemCount: records.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 16),
-                        itemBuilder: (context, index) {
-                          final record = records[index];
-                          final isPresent = record.status == AttendanceStatus.present;
-                          return ModuleCard(
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Text(
-                                  record.teacherName,
-                                  style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                                        fontWeight: FontWeight.w700,
-                                      ),
-                                ),
-                                const SizedBox(height: 8),
-                                Text(
-                                  dateFormat.format(record.date),
-                                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                                        color: Theme.of(context).colorScheme.onSurfaceVariant,
-                                      ),
-                                ),
-                                const SizedBox(height: 12),
-                                Row(
-                                  children: [
-                                    Icon(
-                                      isPresent ? Icons.check_circle : Icons.cancel_outlined,
-                                      color: isPresent
-                                          ? Colors.green
-                                          : Theme.of(context).colorScheme.error,
-                                    ),
-                                    const SizedBox(width: 8),
-                                    Text(
-                                      isPresent ? 'Present' : 'Absent',
-                                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                                            fontWeight: FontWeight.w600,
-                                          ),
-                                    ),
-                                  ],
-                                ),
-                              ],
-                            ),
-                          );
-                        },
-                      );
-                    }),
-                  ],
-                ),
-              ),
-            ],
-          ),
+                          ),
+                        ],
+                      ),
+                    );
+                  },
+                );
+              }),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/modules/attendance/views/admin_teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/admin_teacher_attendance_view.dart
@@ -1,0 +1,242 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+import '../../../data/models/attendance_record_model.dart';
+import '../../common/widgets/module_card.dart';
+import '../../common/widgets/module_empty_state.dart';
+import '../../common/widgets/module_page_container.dart';
+import '../controllers/admin_teacher_attendance_controller.dart';
+
+class AdminTeacherAttendanceView
+    extends GetView<AdminTeacherAttendanceController> {
+  const AdminTeacherAttendanceView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final dateFormat = DateFormat.yMMMMd();
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Teacher Attendance'),
+        centerTitle: true,
+        actions: [
+          Obx(() {
+            final isExporting = controller.isExporting.value;
+            return IconButton(
+              tooltip: 'Download PDF',
+              onPressed:
+                  isExporting ? null : () => controller.exportAttendanceAsPdf(),
+              icon: isExporting
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.picture_as_pdf_outlined),
+            );
+          }),
+          Obx(() {
+            final isSaving = controller.isSaving.value;
+            return Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 8),
+              child: TextButton(
+                onPressed: isSaving ? null : () => controller.saveAttendance(),
+                child: isSaving
+                    ? const SizedBox(
+                        width: 16,
+                        height: 16,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Save'),
+              ),
+            );
+          }),
+        ],
+      ),
+      body: ModulePageContainer(
+        child: Column(
+          children: [
+            _AttendanceHeader(dateFormat: dateFormat),
+            const SizedBox(height: 12),
+            Expanded(
+              child: Obx(() {
+                if (controller.isLoading.value) {
+                  return const Center(child: CircularProgressIndicator());
+                }
+                final entries = controller.currentEntries;
+                if (entries.isEmpty) {
+                  return ListView(
+                    physics: const AlwaysScrollableScrollPhysics(),
+                    padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                    children: const [
+                      ModuleEmptyState(
+                        icon: Icons.person_outline,
+                        title: 'No teachers available',
+                        message:
+                            'Teachers will appear here once they are added to the system.',
+                      ),
+                    ],
+                  );
+                }
+                return ListView.separated(
+                  padding: const EdgeInsets.fromLTRB(16, 0, 16, 24),
+                  itemCount: entries.length,
+                  separatorBuilder: (_, __) => const SizedBox(height: 12),
+                  itemBuilder: (context, index) {
+                    final entry = entries[index];
+                    return _TeacherAttendanceTile(
+                      entry: entry,
+                      onToggle: () => controller.toggleStatus(entry.teacherId),
+                    );
+                  },
+                );
+              }),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _AttendanceHeader extends StatelessWidget {
+  const _AttendanceHeader({required this.dateFormat});
+
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<AdminTeacherAttendanceController>();
+    final theme = Theme.of(context);
+    return Obx(() {
+      final date = controller.selectedDate.value;
+      final entries = controller.currentEntries;
+      final presentCount = entries
+          .where((entry) => entry.status == AttendanceStatus.present)
+          .length;
+      final total = entries.length;
+      return ModuleCard(
+        padding: const EdgeInsets.fromLTRB(20, 16, 20, 20),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    'Attendance for ${dateFormat.format(date)}',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                ),
+                TextButton.icon(
+                  onPressed: () async {
+                    final picked = await showDatePicker(
+                      context: context,
+                      initialDate: date,
+                      firstDate: DateTime(date.year - 1),
+                      lastDate: DateTime(date.year + 1),
+                    );
+                    if (picked != null) {
+                      controller.setDate(picked);
+                    }
+                  },
+                  icon: const Icon(Icons.calendar_today, size: 18),
+                  label: const Text('Change date'),
+                ),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Text(
+              total == 0
+                  ? 'No teachers to mark on this day.'
+                  : '$presentCount of $total teacher${total == 1 ? '' : 's'} marked present.',
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Toggle the switch next to each teacher to mark them present or absent before saving.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.onSurfaceVariant,
+              ),
+            ),
+          ],
+        ),
+      );
+    });
+  }
+}
+
+class _TeacherAttendanceTile extends StatelessWidget {
+  const _TeacherAttendanceTile({required this.entry, required this.onToggle});
+
+  final TeacherAttendanceRecord entry;
+  final VoidCallback onToggle;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isPresent = entry.status == AttendanceStatus.present;
+    final statusColor =
+        isPresent ? Colors.green : theme.colorScheme.error.withOpacity(0.9);
+    return ModuleCard(
+      padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  entry.teacherName,
+                  style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 8),
+                Row(
+                  children: [
+                    Icon(
+                      isPresent ? Icons.check_circle : Icons.cancel_outlined,
+                      color: statusColor,
+                      size: 20,
+                    ),
+                    const SizedBox(width: 6),
+                    Text(
+                      isPresent ? 'Present' : 'Absent',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: statusColor,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+          const SizedBox(width: 12),
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              Switch.adaptive(
+                value: isPresent,
+                onChanged: (_) => onToggle(),
+                activeColor: Colors.green,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                isPresent ? 'Present' : 'Absent',
+                style: theme.textTheme.labelSmall,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- split the admin dashboard attendance entry into dedicated student and teacher flows with a new teacher attendance manager
- allow admins to record and export teacher attendance while keeping student attendance filters in place
- refresh the teacher attendance experience with clearer cards, switch-based toggles, and real PDF exports saved via the existing downloader

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d33b0a469883319a3ce2466b73781e