### PR TITLE
Revamp admin attendance experiences

### DIFF
--- a/lib/data/models/attendance_record_model.dart
+++ b/lib/data/models/attendance_record_model.dart
@@ -141,6 +141,7 @@ class TeacherAttendanceRecord {
   final String id;
   final String teacherId;
   final String teacherName;
+  final String subjectId;
   final DateTime date;
   final AttendanceStatus status;
   final String note;
@@ -149,6 +150,7 @@ class TeacherAttendanceRecord {
     required this.id,
     required this.teacherId,
     required this.teacherName,
+    required this.subjectId,
     required this.date,
     required this.status,
     required this.note,
@@ -160,6 +162,7 @@ class TeacherAttendanceRecord {
       id: doc.id,
       teacherId: data['teacherId'] as String? ?? '',
       teacherName: data['teacherName'] as String? ?? '',
+      subjectId: data['subjectId'] as String? ?? '',
       date: (data['date'] as Timestamp?)?.toDate() ?? DateTime.now(),
       status: AttendanceStatusParser.fromString(data['status'] as String?),
       note: data['note'] as String? ?? '',
@@ -170,6 +173,7 @@ class TeacherAttendanceRecord {
     return <String, dynamic>{
       'teacherId': teacherId,
       'teacherName': teacherName,
+      'subjectId': subjectId,
       'date': Timestamp.fromDate(date),
       'status': status.name,
       'note': note,
@@ -180,6 +184,7 @@ class TeacherAttendanceRecord {
     String? id,
     String? teacherId,
     String? teacherName,
+    String? subjectId,
     DateTime? date,
     AttendanceStatus? status,
     String? note,
@@ -188,6 +193,7 @@ class TeacherAttendanceRecord {
       id: id ?? this.id,
       teacherId: teacherId ?? this.teacherId,
       teacherName: teacherName ?? this.teacherName,
+      subjectId: subjectId ?? this.subjectId,
       date: date ?? this.date,
       status: status ?? this.status,
       note: note ?? this.note,

--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -5,7 +5,9 @@ import 'package:get/get.dart';
 
 import '../../../core/services/database_service.dart';
 import '../../../data/models/attendance_record_model.dart';
+import '../../../data/models/child_model.dart';
 import '../../../data/models/school_class_model.dart';
+import '../../../data/models/subject_model.dart';
 import '../../../data/models/teacher_model.dart';
 
 class AdminAttendanceController extends GetxController {
@@ -13,11 +15,15 @@ class AdminAttendanceController extends GetxController {
 
   StreamSubscription? _classesSubscription;
   StreamSubscription? _teachersSubscription;
+  StreamSubscription? _subjectsSubscription;
+  StreamSubscription? _childrenSubscription;
   StreamSubscription? _sessionsSubscription;
 
   bool _classesLoaded = false;
   bool _teachersLoaded = false;
   bool _sessionsLoaded = false;
+  bool _subjectsLoaded = false;
+  bool _childrenLoaded = false;
 
   @override
   void onInit() {
@@ -29,6 +35,8 @@ class AdminAttendanceController extends GetxController {
   void onClose() {
     _classesSubscription?.cancel();
     _teachersSubscription?.cancel();
+    _subjectsSubscription?.cancel();
+    _childrenSubscription?.cancel();
     _sessionsSubscription?.cancel();
     super.onClose();
   }
@@ -40,15 +48,17 @@ class AdminAttendanceController extends GetxController {
 
   final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
   final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
+  final RxList<SubjectModel> subjects = <SubjectModel>[].obs;
+  final RxList<ChildModel> children = <ChildModel>[].obs;
+  final RxList<ChildAttendanceSummary> childSummaries =
+      <ChildAttendanceSummary>[].obs;
 
   final RxnString classFilter = RxnString();
-  final RxnString teacherFilter = RxnString();
   final Rx<DateTime?> dateFilter = Rx<DateTime?>(null);
   final RxBool isLoading = false.obs;
 
   void clearFilters() {
     classFilter.value = null;
-    teacherFilter.value = null;
     dateFilter.value = null;
     _applySessionFilters();
   }
@@ -60,15 +70,14 @@ class AdminAttendanceController extends GetxController {
         'Class';
   }
 
-  String teacherName(String teacherId) {
-    return teachers
-            .firstWhereOrNull((item) => item.id == teacherId)
-            ?.name ??
-        'Teacher';
+  String? subjectName(String subjectId) {
+    return subjects.firstWhereOrNull((item) => item.id == subjectId)?.name;
   }
 
   void setClasses(List<SchoolClassModel> items) {
-    classes.assignAll(items);
+    final sorted = List<SchoolClassModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    classes.assignAll(sorted);
     if (classFilter.value != null &&
         classes.firstWhereOrNull((item) => item.id == classFilter.value) ==
             null) {
@@ -80,14 +89,29 @@ class AdminAttendanceController extends GetxController {
   }
 
   void setTeachers(List<TeacherModel> items) {
-    teachers.assignAll(items);
-    if (teacherFilter.value != null &&
-        teachers.firstWhereOrNull((item) => item.id == teacherFilter.value) ==
-            null) {
-      teacherFilter.value = null;
-    }
+    final sorted = List<TeacherModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    teachers.assignAll(sorted);
     _applySessionFilters();
     _teachersLoaded = true;
+    _maybeFinishLoading();
+  }
+
+  void setSubjects(List<SubjectModel> items) {
+    final sorted = List<SubjectModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    subjects.assignAll(sorted);
+    _subjectsLoaded = true;
+    _buildChildSummaries();
+    _maybeFinishLoading();
+  }
+
+  void setChildren(List<ChildModel> items) {
+    final sorted = List<ChildModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    children.assignAll(sorted);
+    _childrenLoaded = true;
+    _buildChildSummaries();
     _maybeFinishLoading();
   }
 
@@ -103,11 +127,6 @@ class AdminAttendanceController extends GetxController {
     _applySessionFilters();
   }
 
-  void setTeacherFilter(String? teacherId) {
-    teacherFilter.value = teacherId;
-    _applySessionFilters();
-  }
-
   void setDateFilter(DateTime? date) {
     dateFilter.value = date;
     _applySessionFilters();
@@ -115,18 +134,111 @@ class AdminAttendanceController extends GetxController {
 
   void _applySessionFilters() {
     final classId = classFilter.value;
-    final teacherId = teacherFilter.value;
     final date = dateFilter.value;
     final filtered = _allClassSessions.where((session) {
       final matchesClass =
           classId == null || classId.isEmpty || session.classId == classId;
-      final matchesTeacher =
-          teacherId == null || teacherId.isEmpty || session.teacherId == teacherId;
       final matchesDate = date == null ? true : _isSameDay(session.date, date);
-      return matchesClass && matchesTeacher && matchesDate;
+      return matchesClass && matchesDate;
     }).toList()
       ..sort((a, b) => b.date.compareTo(a.date));
     classSessions.assignAll(filtered);
+    _buildChildSummaries();
+  }
+
+  void _buildChildSummaries() {
+    if (classSessions.isEmpty) {
+      childSummaries.clear();
+      return;
+    }
+    final summaries = <String, _ChildSummaryBuilder>{};
+    final childrenById = {for (final child in children) child.id: child};
+    final classesById = {for (final item in classes) item.id: item};
+
+    for (final session in classSessions) {
+      final participants = <String, String>{};
+      final classChildren =
+          children.where((child) => child.classId == session.classId);
+      if (classChildren.isNotEmpty) {
+        for (final child in classChildren) {
+          if (child.id.isEmpty) continue;
+          participants[child.id] = child.name;
+        }
+      }
+      if (participants.isEmpty) {
+        for (final record in session.records) {
+          if (record.childId.isEmpty) continue;
+          participants.putIfAbsent(record.childId, () => record.childName);
+        }
+      }
+      if (participants.isEmpty) {
+        continue;
+      }
+
+      for (final entry in participants.entries) {
+        final childId = entry.key;
+        if (childId.isEmpty) {
+          continue;
+        }
+        final childModel = childrenById[childId];
+        final displayName = childModel?.name ?? entry.value;
+        final resolvedName =
+            displayName.trim().isEmpty ? 'Student' : displayName.trim();
+        final resolvedClassId = childModel?.classId.isNotEmpty == true
+            ? childModel!.classId
+            : session.classId;
+        final resolvedClassName = resolvedClassId.isNotEmpty
+            ? classesById[resolvedClassId]?.name ?? session.className
+            : session.className;
+        final builder = summaries.putIfAbsent(childId, () {
+          return _ChildSummaryBuilder(
+            childId: childId,
+            childName: resolvedName,
+            classId: resolvedClassId,
+            className: resolvedClassName,
+          );
+        });
+        builder.childName = resolvedName;
+        if (resolvedClassId.isNotEmpty) {
+          builder.classId = resolvedClassId;
+          builder.className = resolvedClassName;
+        }
+
+        final record = session.records
+            .firstWhereOrNull((item) => item.childId == childId);
+        final teacher = teachers
+            .firstWhereOrNull((item) => item.id == session.teacherId);
+        final subjectLabel = teacher == null || teacher.subjectId.isEmpty
+            ? session.teacherName
+            : (subjectName(teacher.subjectId) ?? session.teacherName);
+        final bool isPending = !session.isSubmitted || record == null;
+
+        builder.entries.add(
+          ChildSubjectAttendance(
+            sessionId: session.id,
+            subjectLabel:
+                subjectLabel.trim().isEmpty ? session.teacherName : subjectLabel,
+            teacherName: session.teacherName,
+            date: session.date,
+            isSubmitted: !isPending,
+            status: isPending ? null : record!.status,
+          ),
+        );
+      }
+    }
+
+    final results = summaries.values
+        .map((builder) => builder.build())
+        .toList()
+      ..sort((a, b) {
+        final classCompare =
+            a.className.toLowerCase().compareTo(b.className.toLowerCase());
+        if (classCompare != 0) {
+          return classCompare;
+        }
+        return a.childName.toLowerCase().compareTo(b.childName.toLowerCase());
+      });
+    childSummaries.assignAll(results);
   }
 
   bool _isSameDay(DateTime a, DateTime b) {
@@ -151,6 +263,20 @@ class AdminAttendanceController extends GetxController {
         setTeachers(snapshot.docs.map(TeacherModel.fromDoc).toList());
       });
 
+      _subjectsSubscription = _db.firestore
+          .collection('subjects')
+          .snapshots()
+          .listen((snapshot) {
+        setSubjects(snapshot.docs.map(SubjectModel.fromDoc).toList());
+      });
+
+      _childrenSubscription = _db.firestore
+          .collection('children')
+          .snapshots()
+          .listen((snapshot) {
+        setChildren(snapshot.docs.map(ChildModel.fromDoc).toList());
+      });
+
       _sessionsSubscription = _db.firestore
           .collection('attendanceSessions')
           .snapshots()
@@ -171,8 +297,84 @@ class AdminAttendanceController extends GetxController {
   }
 
   void _maybeFinishLoading() {
-    if (_classesLoaded && _teachersLoaded && _sessionsLoaded) {
+    if (_classesLoaded &&
+        _teachersLoaded &&
+        _sessionsLoaded &&
+        _subjectsLoaded &&
+        _childrenLoaded) {
       isLoading.value = false;
     }
+  }
+}
+
+class ChildAttendanceSummary {
+  ChildAttendanceSummary({
+    required this.childId,
+    required this.childName,
+    required this.classId,
+    required this.className,
+    required List<ChildSubjectAttendance> subjectEntries,
+  }) : subjectEntries = List<ChildSubjectAttendance>.unmodifiable(
+          subjectEntries..sort((a, b) => b.date.compareTo(a.date)),
+        );
+
+  final String childId;
+  final String childName;
+  final String classId;
+  final String className;
+  final List<ChildSubjectAttendance> subjectEntries;
+
+  int get presentCount =>
+      subjectEntries.where((entry) => entry.status == AttendanceStatus.present).length;
+
+  int get absentCount =>
+      subjectEntries.where((entry) => entry.status == AttendanceStatus.absent).length;
+
+  int get pendingCount =>
+      subjectEntries.where((entry) => entry.status == null || !entry.isSubmitted).length;
+
+  int get totalSubjects => subjectEntries.length;
+}
+
+class ChildSubjectAttendance {
+  const ChildSubjectAttendance({
+    required this.sessionId,
+    required this.subjectLabel,
+    required this.teacherName,
+    required this.date,
+    required this.isSubmitted,
+    this.status,
+  });
+
+  final String sessionId;
+  final String subjectLabel;
+  final String teacherName;
+  final DateTime date;
+  final bool isSubmitted;
+  final AttendanceStatus? status;
+}
+
+class _ChildSummaryBuilder {
+  _ChildSummaryBuilder({
+    required this.childId,
+    required this.childName,
+    required this.classId,
+    required this.className,
+  });
+
+  final String childId;
+  String childName;
+  String classId;
+  String className;
+  final List<ChildSubjectAttendance> entries = <ChildSubjectAttendance>[];
+
+  ChildAttendanceSummary build() {
+    return ChildAttendanceSummary(
+      childId: childId,
+      childName: childName,
+      classId: classId,
+      className: className,
+      subjectEntries: List<ChildSubjectAttendance>.from(entries),
+    );
   }
 }

--- a/lib/modules/attendance/views/admin_child_attendance_detail_view.dart
+++ b/lib/modules/attendance/views/admin_child_attendance_detail_view.dart
@@ -1,0 +1,259 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../data/models/attendance_record_model.dart';
+import '../../common/widgets/module_card.dart';
+import '../../common/widgets/module_page_container.dart';
+import '../controllers/admin_attendance_controller.dart';
+
+class AdminChildAttendanceDetailView extends StatelessWidget {
+  const AdminChildAttendanceDetailView({super.key, required this.summary});
+
+  final ChildAttendanceSummary summary;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat.yMMMd();
+    final pendingCount = summary.pendingCount;
+    final absentCount = summary.absentCount;
+    final presentCount = summary.presentCount;
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Student Attendance'),
+        centerTitle: true,
+      ),
+      body: ModulePageContainer(
+        child: ListView(
+          padding: const EdgeInsets.fromLTRB(16, 24, 16, 32),
+          children: [
+            ModuleCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      CircleAvatar(
+                        radius: 28,
+                        backgroundColor:
+                            theme.colorScheme.primary.withOpacity(0.12),
+                        child: Text(
+                          summary.childName.isNotEmpty
+                              ? summary.childName[0].toUpperCase()
+                              : '?',
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            color: theme.colorScheme.primary,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 16),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              summary.childName,
+                              style: theme.textTheme.titleLarge?.copyWith(
+                                fontWeight: FontWeight.w700,
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            Text(
+                              summary.className,
+                              style: theme.textTheme.bodyMedium?.copyWith(
+                                color: theme.colorScheme.onSurfaceVariant,
+                              ),
+                            ),
+                            const SizedBox(height: 12),
+                            Text(
+                              '${summary.totalSubjects} subject${summary.totalSubjects == 1 ? '' : 's'} tracked',
+                              style: theme.textTheme.bodyMedium,
+                            ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  Wrap(
+                    spacing: 10,
+                    runSpacing: 10,
+                    children: [
+                      if (presentCount > 0)
+                        _DetailSummaryChip(
+                          icon: Icons.check_circle,
+                          label: '$presentCount present',
+                          backgroundColor: Colors.green.shade50,
+                          foregroundColor: Colors.green.shade600,
+                        ),
+                      if (absentCount > 0)
+                        _DetailSummaryChip(
+                          icon: Icons.cancel_outlined,
+                          label: '$absentCount absent',
+                          backgroundColor:
+                              theme.colorScheme.error.withOpacity(0.12),
+                          foregroundColor: theme.colorScheme.error,
+                        ),
+                      if (pendingCount > 0)
+                        _DetailSummaryChip(
+                          icon: Icons.hourglass_empty,
+                          label: '$pendingCount pending',
+                          backgroundColor:
+                              theme.colorScheme.primary.withOpacity(0.12),
+                          foregroundColor: theme.colorScheme.primary,
+                        ),
+                    ],
+                  ),
+                ],
+              ),
+            ),
+            const SizedBox(height: 24),
+            ModuleCard(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    'Subject attendance',
+                    style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.w700,
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  ...List.generate(summary.subjectEntries.length, (index) {
+                    final entry = summary.subjectEntries[index];
+                    final isPending = !entry.isSubmitted || entry.status == null;
+                    final status = entry.status;
+                    final Color statusColor;
+                    final String statusLabel;
+                    final IconData statusIcon;
+                    if (isPending) {
+                      statusColor =
+                          theme.colorScheme.onSurfaceVariant.withOpacity(0.8);
+                      statusLabel = 'Not submitted yet';
+                      statusIcon = Icons.hourglass_bottom;
+                    } else if (status == AttendanceStatus.present) {
+                      statusColor = Colors.green.shade600;
+                      statusLabel = 'Present';
+                      statusIcon = Icons.check_circle;
+                    } else {
+                      statusColor = theme.colorScheme.error;
+                      statusLabel = 'Absent';
+                      statusIcon = Icons.cancel_outlined;
+                    }
+
+                    return Column(
+                      children: [
+                        if (index != 0) const Divider(height: 24),
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Container(
+                              padding: const EdgeInsets.all(10),
+                              decoration: BoxDecoration(
+                                color:
+                                    theme.colorScheme.primary.withOpacity(0.12),
+                                borderRadius: BorderRadius.circular(14),
+                              ),
+                              child: Icon(
+                                Icons.book_outlined,
+                                color: theme.colorScheme.primary,
+                                size: 22,
+                              ),
+                            ),
+                            const SizedBox(width: 12),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    entry.subjectLabel,
+                                    style: theme.textTheme.titleMedium?.copyWith(
+                                      fontWeight: FontWeight.w600,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 6),
+                                  Text(
+                                    entry.teacherName,
+                                    style: theme.textTheme.bodySmall,
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    dateFormat.format(entry.date),
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color:
+                                          theme.colorScheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ],
+                              ),
+                            ),
+                            Column(
+                              crossAxisAlignment: CrossAxisAlignment.end,
+                              children: [
+                                Icon(statusIcon, color: statusColor, size: 22),
+                                const SizedBox(height: 6),
+                                Text(
+                                  statusLabel,
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color: statusColor,
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ],
+                        ),
+                      ],
+                    );
+                  }),
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _DetailSummaryChip extends StatelessWidget {
+  const _DetailSummaryChip({
+    required this.icon,
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: foregroundColor),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: foregroundColor,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/modules/behavior/widgets/behavior_type_chip.dart
+++ b/lib/modules/behavior/widgets/behavior_type_chip.dart
@@ -37,7 +37,10 @@ class BehaviorTypeChip extends StatelessWidget {
         color: textColor,
         fontWeight: FontWeight.w600,
       ),
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(18),
+        side: BorderSide.none,
+      ),
     );
   }
 }


### PR DESCRIPTION
## Summary
- add class and subject filters plus refreshed cards for admin teacher attendance, and include subjects in the exported PDF
- reorganize the admin student attendance list around per-child summaries with a detailed view and smoother date filter styling
- simplify behavior type chips to remove the dark outline

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d3445c3e648331b0988418132867f4