### PR TITLE
Improve attendance summaries and parent views

### DIFF
--- a/lib/modules/attendance/controllers/parent_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/parent_attendance_controller.dart
@@ -2,11 +2,19 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+import 'package:pdf/pdf.dart';
+import 'package:pdf/widgets.dart' as pw;
 
 import '../../../core/services/auth_service.dart';
 import '../../../core/services/database_service.dart';
+import '../../../core/services/pdf_downloader/pdf_downloader.dart';
 import '../../../data/models/attendance_record_model.dart';
 import '../../../data/models/child_model.dart';
+import '../../../data/models/school_class_model.dart';
+import '../../../data/models/subject_model.dart';
+import '../../../data/models/teacher_model.dart';
+import '../models/child_attendance_summary.dart';
 
 class ParentAttendanceController extends GetxController {
   final DatabaseService _db = Get.find();
@@ -14,9 +22,15 @@ class ParentAttendanceController extends GetxController {
 
   StreamSubscription? _childrenSubscription;
   StreamSubscription? _sessionsSubscription;
+  StreamSubscription? _classesSubscription;
+  StreamSubscription? _teachersSubscription;
+  StreamSubscription? _subjectsSubscription;
 
   bool _childrenLoaded = false;
   bool _sessionsLoaded = false;
+  bool _classesLoaded = false;
+  bool _teachersLoaded = false;
+  bool _subjectsLoaded = false;
 
   final Set<String> _childIds = <String>{};
 
@@ -30,6 +44,9 @@ class ParentAttendanceController extends GetxController {
   void onClose() {
     _childrenSubscription?.cancel();
     _sessionsSubscription?.cancel();
+    _classesSubscription?.cancel();
+    _teachersSubscription?.cancel();
+    _subjectsSubscription?.cancel();
     super.onClose();
   }
 
@@ -38,12 +55,23 @@ class ParentAttendanceController extends GetxController {
   final RxList<AttendanceSessionModel> sessions =
       <AttendanceSessionModel>[].obs;
   final RxList<ChildModel> children = <ChildModel>[].obs;
+  final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
+  final RxList<TeacherModel> teachers = <TeacherModel>[].obs;
+  final RxList<SubjectModel> subjects = <SubjectModel>[].obs;
+
+  final RxList<ChildAttendanceSummary> _allChildSummaries =
+      <ChildAttendanceSummary>[].obs;
+  final RxList<ChildAttendanceSummary> childSummaries =
+      <ChildAttendanceSummary>[].obs;
 
   final RxnString childFilter = RxnString();
+  final Rx<DateTime?> dateFilter = Rx<DateTime?>(null);
   final RxBool isLoading = false.obs;
+  final RxnString exportingChildId = RxnString();
 
   void clearFilters() {
     childFilter.value = null;
+    dateFilter.value = null;
     _applyFilters();
   }
 
@@ -66,8 +94,38 @@ class ParentAttendanceController extends GetxController {
     _maybeFinishLoading();
   }
 
+  void setClasses(List<SchoolClassModel> items) {
+    final sorted = List<SchoolClassModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    classes.assignAll(sorted);
+    _classesLoaded = true;
+    _applyFilters();
+    _maybeFinishLoading();
+  }
+
+  void setTeachers(List<TeacherModel> items) {
+    final sorted = List<TeacherModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    teachers.assignAll(sorted);
+    _teachersLoaded = true;
+    _applyFilters();
+    _maybeFinishLoading();
+  }
+
+  void setSubjects(List<SubjectModel> items) {
+    final sorted = List<SubjectModel>.from(items)
+      ..sort((a, b) => a.name.compareTo(b.name));
+    subjects.assignAll(sorted);
+    _subjectsLoaded = true;
+    _applyFilters();
+    _maybeFinishLoading();
+  }
+
   void setSessions(List<AttendanceSessionModel> items) {
-    _allSessions.assignAll(items);
+    final normalized = items
+        .map((session) => session.copyWith(date: _normalizeDate(session.date)))
+        .toList();
+    _allSessions.assignAll(normalized);
     _applyFilters();
     _sessionsLoaded = true;
     _maybeFinishLoading();
@@ -75,36 +133,349 @@ class ParentAttendanceController extends GetxController {
 
   void setChildFilter(String? childId) {
     childFilter.value = childId;
+    _applySummaryFilters();
+  }
+
+  void setDateFilter(DateTime? date) {
+    dateFilter.value = date == null ? null : _normalizeDate(date);
     _applyFilters();
   }
 
   void _applyFilters() {
-    final childId = childFilter.value;
     if (_childIds.isEmpty) {
       sessions.clear();
+      _allChildSummaries.clear();
+      childSummaries.clear();
       return;
     }
+
+    final targetDate = dateFilter.value;
     final relevantSessions = _allSessions.where((session) {
-      return session.records
-          .any((entry) => _childIds.contains(entry.childId));
+      final hasChild =
+          session.records.any((entry) => _childIds.contains(entry.childId));
+      if (!hasChild) {
+        return false;
+      }
+      if (targetDate != null && !_isSameDay(session.date, targetDate)) {
+        return false;
+      }
+      return true;
     }).toList()
       ..sort((a, b) => b.date.compareTo(a.date));
 
-    if (childId == null || childId.isEmpty) {
-      sessions.assignAll(relevantSessions);
+    sessions.assignAll(relevantSessions);
+    _buildChildSummaries(relevantSessions);
+  }
+
+  void _buildChildSummaries(List<AttendanceSessionModel> sessionList) {
+    if (_childIds.isEmpty) {
+      _allChildSummaries.clear();
+      childSummaries.clear();
       return;
     }
 
-    final filtered = relevantSessions
-        .where((session) =>
-            session.records.any((entry) => entry.childId == childId))
-        .toList();
-    sessions.assignAll(filtered);
+    final builders = <String, ChildAttendanceSummaryBuilder>{};
+    final childrenById = {for (final child in children) child.id: child};
+    final classesById = {for (final item in classes) item.id: item};
+    final teachersById = {for (final item in teachers) item.id: item};
+    final subjectsById = {for (final item in subjects) item.id: item};
+
+    final classScope = <String>{};
+    for (final child in children) {
+      if (child.classId.isNotEmpty) {
+        classScope.add(child.classId);
+      }
+    }
+    for (final session in sessionList) {
+      if (session.records.any((entry) => _childIds.contains(entry.childId))) {
+        classScope.add(session.classId);
+      }
+    }
+    if (classScope.isEmpty) {
+      _allChildSummaries.clear();
+      childSummaries.clear();
+      return;
+    }
+
+    for (final child in children) {
+      if (child.id.isEmpty) continue;
+      final classModel = classesById[child.classId];
+      final resolvedName =
+          child.name.trim().isEmpty ? 'Student' : child.name.trim();
+      final builder = builders.putIfAbsent(child.id, () {
+        return ChildAttendanceSummaryBuilder(
+          childId: child.id,
+          childName: resolvedName,
+          classId: child.classId,
+          className: classModel?.name ?? 'Class',
+        );
+      });
+      builder.childName = resolvedName;
+      if (child.classId.isNotEmpty) {
+        builder.classId = child.classId;
+        builder.className = classModel?.name ?? builder.className;
+      }
+    }
+
+    for (final session in sessionList) {
+      final normalizedDate = _normalizeDate(session.date);
+      final participants = <String, String>{};
+      for (final record in session.records) {
+        if (_childIds.contains(record.childId)) {
+          participants.putIfAbsent(record.childId, () => record.childName);
+        }
+      }
+      if (participants.isEmpty) {
+        continue;
+      }
+
+      for (final entry in participants.entries) {
+        final childId = entry.key;
+        final childModel = childrenById[childId];
+        final displayName = childModel?.name ?? entry.value;
+        final resolvedName =
+            displayName.trim().isEmpty ? 'Student' : displayName.trim();
+        final builder = builders.putIfAbsent(childId, () {
+          return ChildAttendanceSummaryBuilder(
+            childId: childId,
+            childName: resolvedName,
+            classId: childModel?.classId ?? session.classId,
+            className: childModel?.classId.isNotEmpty == true
+                ? classesById[childModel!.classId]?.name ?? session.className
+                : session.className,
+          );
+        });
+        builder.childName = resolvedName;
+        if (childModel?.classId.isNotEmpty == true) {
+          builder.classId = childModel!.classId;
+          builder.className =
+              classesById[childModel.classId]?.name ?? builder.className;
+        } else if (session.classId.isNotEmpty) {
+          builder.classId = session.classId;
+          builder.className = session.className;
+        }
+
+        final record =
+            session.records.firstWhereOrNull((item) => item.childId == childId);
+        final teacherModel = teachersById[session.teacherId];
+        final subjectId = teacherModel?.subjectId ?? '';
+        final subjectModel =
+            subjectId.isEmpty ? null : subjectsById[subjectId];
+        final subjectLabel = (subjectModel?.name ?? '').trim().isNotEmpty
+            ? subjectModel!.name.trim()
+            : session.teacherName;
+        final teacherName = (teacherModel?.name ?? '').trim().isNotEmpty
+            ? teacherModel!.name.trim()
+            : session.teacherName;
+        final bool isPending = !session.isSubmitted || record == null;
+
+        builder.addOrUpdateEntry(
+          ChildSubjectAttendance(
+            sessionId: session.id,
+            subjectId: subjectId,
+            teacherId: session.teacherId,
+            subjectLabel:
+                subjectLabel.isEmpty ? session.teacherName : subjectLabel,
+            teacherName: teacherName.isEmpty ? session.teacherName : teacherName,
+            date: normalizedDate,
+            isSubmitted: !isPending,
+            status: isPending ? null : record!.status,
+            submittedAt: session.submittedAt,
+          ),
+        );
+      }
+    }
+
+    final placeholderDate =
+        _normalizeDate(dateFilter.value ?? DateTime.now());
+    for (final classId in classScope) {
+      final classModel = classesById[classId];
+      if (classModel == null || classModel.teacherSubjects.isEmpty) {
+        continue;
+      }
+      final classChildren =
+          children.where((child) => child.classId == classId).toList();
+      if (classChildren.isEmpty) {
+        continue;
+      }
+
+      for (final child in classChildren) {
+        if (child.id.isEmpty) continue;
+        final resolvedName =
+            child.name.trim().isEmpty ? 'Student' : child.name.trim();
+        final builder = builders.putIfAbsent(child.id, () {
+          return ChildAttendanceSummaryBuilder(
+            childId: child.id,
+            childName: resolvedName,
+            classId: classId,
+            className: classModel.name,
+          );
+        });
+        builder.childName = resolvedName;
+        builder.classId = classId;
+        builder.className = classModel.name;
+
+        for (final subjectEntry in classModel.teacherSubjects.entries) {
+          final subjectId = subjectEntry.key;
+          final teacherId = subjectEntry.value;
+          if (subjectId.isEmpty && teacherId.isEmpty) {
+            continue;
+          }
+          final teacherModel =
+              teacherId.isEmpty ? null : teachersById[teacherId];
+          final subjectModel =
+              subjectId.isEmpty ? null : subjectsById[subjectId];
+          final subjectName = (subjectModel?.name ?? '').trim();
+          final teacherDisplayName = (teacherModel?.name ?? '').trim();
+          final resolvedSubjectLabel = subjectName.isNotEmpty
+              ? subjectName
+              : (teacherDisplayName.isNotEmpty
+                  ? teacherDisplayName
+                  : 'Subject');
+          final resolvedTeacherName = teacherDisplayName.isNotEmpty
+              ? teacherDisplayName
+              : (teacherId.isEmpty ? 'Unassigned teacher' : 'Unknown teacher');
+
+          builder.addOrUpdateEntry(
+            ChildSubjectAttendance(
+              sessionId:
+                  'pending-${child.id}-${subjectId.isNotEmpty ? subjectId : teacherId}-${_formatDateKey(placeholderDate)}',
+              subjectId: subjectId,
+              teacherId: teacherId,
+              subjectLabel: resolvedSubjectLabel,
+              teacherName: resolvedTeacherName,
+              date: placeholderDate,
+              isSubmitted: false,
+              status: null,
+            ),
+          );
+        }
+      }
+    }
+
+    final results = builders.values
+        .map((builder) => builder.build())
+        .toList()
+      ..sort((a, b) =>
+          a.childName.toLowerCase().compareTo(b.childName.toLowerCase()));
+
+    _allChildSummaries.assignAll(results);
+    _applySummaryFilters();
   }
 
-  ChildAttendanceEntry? entryFor(AttendanceSessionModel session, String childId) {
-    return session.records
-        .firstWhereOrNull((entry) => entry.childId == childId);
+  void _applySummaryFilters() {
+    final selectedChild = childFilter.value;
+    if (selectedChild == null || selectedChild.isEmpty) {
+      childSummaries.assignAll(_allChildSummaries);
+      return;
+    }
+    childSummaries.assignAll(
+      _allChildSummaries.where((summary) => summary.childId == selectedChild),
+    );
+  }
+
+  Future<void> exportChildAttendanceAsPdf(
+      ChildAttendanceSummary summary) async {
+    if (summary.subjectEntries.isEmpty) {
+      Get.snackbar(
+        'Nothing to export',
+        'No attendance records are available for ${summary.childName}.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+
+    if (exportingChildId.value != null) {
+      return;
+    }
+
+    exportingChildId.value = summary.childId;
+    try {
+      final doc = pw.Document();
+      final dateFormatter = DateFormat.yMMMd();
+      final now = DateTime.now();
+      final tableData = summary.subjectEntries.map((entry) {
+        final statusLabel =
+            entry.isSubmitted && entry.status != null ? entry.status!.label : 'Pending';
+        return [
+          dateFormatter.format(entry.date),
+          entry.subjectLabel,
+          entry.teacherName,
+          statusLabel,
+        ];
+      }).toList();
+
+      doc.addPage(
+        pw.MultiPage(
+          build: (context) => [
+            pw.Header(
+              level: 0,
+              child: pw.Text(
+                'Attendance – ${summary.childName}',
+                style: pw.TextStyle(
+                  fontSize: 22,
+                  fontWeight: pw.FontWeight.bold,
+                ),
+              ),
+            ),
+            pw.Text(
+              'Class: ${summary.className.isNotEmpty ? summary.className : 'Class'}',
+            ),
+            pw.SizedBox(height: 4),
+            pw.Text('Generated on ${DateFormat.yMMMMd().format(now)}'),
+            pw.SizedBox(height: 12),
+            pw.Text(
+              '${summary.presentCount} present • ${summary.absentCount} absent • ${summary.pendingCount} pending',
+              style: const pw.TextStyle(fontSize: 12),
+            ),
+            pw.SizedBox(height: 16),
+            pw.Table.fromTextArray(
+              headers: const ['Date', 'Subject', 'Teacher', 'Status'],
+              data: tableData,
+              headerStyle: pw.TextStyle(
+                fontWeight: pw.FontWeight.bold,
+                color: PdfColors.black,
+              ),
+              headerDecoration: const pw.BoxDecoration(color: PdfColors.grey300),
+              cellStyle: const pw.TextStyle(fontSize: 11),
+              cellAlignment: pw.Alignment.centerLeft,
+              columnWidths: {
+                0: const pw.FlexColumnWidth(1.2),
+                1: const pw.FlexColumnWidth(2.2),
+                2: const pw.FlexColumnWidth(1.8),
+                3: const pw.FlexColumnWidth(1.1),
+              },
+            ),
+          ],
+        ),
+      );
+
+      final sanitizedChild =
+          _sanitizeFileName(summary.childName.isEmpty ? 'student' : summary.childName);
+      final sanitizedClass =
+          _sanitizeFileName(summary.className.isEmpty ? 'class' : summary.className);
+      final dateStamp = DateFormat('yyyyMMdd').format(now);
+      final fileName =
+          'attendance-${sanitizedChild.isEmpty ? 'student' : sanitizedChild}-${sanitizedClass.isEmpty ? 'class' : sanitizedClass}-$dateStamp.pdf';
+      final bytes = await doc.save();
+      final savedPath = await savePdf(bytes, fileName);
+      Get.closeCurrentSnackbar();
+      Get.snackbar(
+        'Download complete',
+        savedPath != null
+            ? 'Saved to $savedPath'
+            : 'The PDF download has started.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } catch (error) {
+      Get.snackbar(
+        'Export failed',
+        'Unable to create the PDF: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    } finally {
+      exportingChildId.value = null;
+    }
   }
 
   void _initialize() {
@@ -134,11 +505,61 @@ class ParentAttendanceController extends GetxController {
         .listen((snapshot) {
       setSessions(snapshot.docs.map(AttendanceSessionModel.fromDoc).toList());
     });
+
+    _classesSubscription = _db.firestore
+        .collection('classes')
+        .snapshots()
+        .listen((snapshot) {
+      setClasses(snapshot.docs.map(SchoolClassModel.fromDoc).toList());
+    });
+
+    _teachersSubscription = _db.firestore
+        .collection('teachers')
+        .snapshots()
+        .listen((snapshot) {
+      setTeachers(snapshot.docs.map(TeacherModel.fromDoc).toList());
+    });
+
+    _subjectsSubscription = _db.firestore
+        .collection('subjects')
+        .snapshots()
+        .listen((snapshot) {
+      setSubjects(snapshot.docs.map(SubjectModel.fromDoc).toList());
+    });
   }
 
   void _maybeFinishLoading() {
-    if (_childrenLoaded && _sessionsLoaded) {
+    if (_childrenLoaded &&
+        _sessionsLoaded &&
+        _classesLoaded &&
+        _teachersLoaded &&
+        _subjectsLoaded) {
       isLoading.value = false;
     }
+  }
+
+  DateTime _normalizeDate(DateTime date) {
+    return DateTime(date.year, date.month, date.day);
+  }
+
+  bool _isSameDay(DateTime a, DateTime b) {
+    return a.year == b.year && a.month == b.month && a.day == b.day;
+  }
+
+  String _formatDateKey(DateTime date) {
+    final normalized = _normalizeDate(date);
+    final year = normalized.year.toString().padLeft(4, '0');
+    final month = normalized.month.toString().padLeft(2, '0');
+    final day = normalized.day.toString().padLeft(2, '0');
+    return '$year$month$day';
+  }
+
+  String _sanitizeFileName(String value) {
+    final normalized = value
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '-')
+        .replaceAll(RegExp(r'-{2,}'), '-')
+        .replaceAll(RegExp(r'^-+|-+$'), '');
+    return normalized;
   }
 }

--- a/lib/modules/attendance/models/child_attendance_summary.dart
+++ b/lib/modules/attendance/models/child_attendance_summary.dart
@@ -1,0 +1,131 @@
+import 'package:intl/intl.dart';
+
+import '../../../data/models/attendance_record_model.dart';
+
+class ChildSubjectAttendance {
+  const ChildSubjectAttendance({
+    required this.sessionId,
+    this.subjectId = '',
+    this.teacherId = '',
+    required this.subjectLabel,
+    required this.teacherName,
+    required this.date,
+    required this.isSubmitted,
+    this.status,
+    this.submittedAt,
+  });
+
+  final String sessionId;
+  final String subjectId;
+  final String teacherId;
+  final String subjectLabel;
+  final String teacherName;
+  final DateTime date;
+  final bool isSubmitted;
+  final AttendanceStatus? status;
+  final DateTime? submittedAt;
+}
+
+class ChildAttendanceSummary {
+  ChildAttendanceSummary({
+    required this.childId,
+    required this.childName,
+    required this.classId,
+    required this.className,
+    required List<ChildSubjectAttendance> subjectEntries,
+  }) : subjectEntries = List<ChildSubjectAttendance>.unmodifiable(
+          subjectEntries..sort((a, b) => b.date.compareTo(a.date)),
+        );
+
+  final String childId;
+  final String childName;
+  final String classId;
+  final String className;
+  final List<ChildSubjectAttendance> subjectEntries;
+
+  int get presentCount =>
+      subjectEntries.where((entry) => entry.status == AttendanceStatus.present).length;
+
+  int get absentCount =>
+      subjectEntries.where((entry) => entry.status == AttendanceStatus.absent).length;
+
+  int get pendingCount =>
+      subjectEntries.where((entry) => entry.status == null || !entry.isSubmitted).length;
+
+  int get totalSubjects => subjectEntries.length;
+}
+
+class ChildAttendanceSummaryBuilder {
+  ChildAttendanceSummaryBuilder({
+    required this.childId,
+    required this.childName,
+    required this.classId,
+    required this.className,
+  });
+
+  final String childId;
+  String childName;
+  String classId;
+  String className;
+
+  final List<ChildSubjectAttendance> _entries = <ChildSubjectAttendance>[];
+  final Map<String, int> _entryIndexByKey = <String, int>{};
+
+  void addOrUpdateEntry(ChildSubjectAttendance entry) {
+    final key = _entryKey(entry);
+    final existingIndex = _entryIndexByKey[key];
+    if (existingIndex == null) {
+      _entryIndexByKey[key] = _entries.length;
+      _entries.add(entry);
+      return;
+    }
+
+    final existing = _entries[existingIndex];
+    if (_shouldReplace(existing, entry)) {
+      _entries[existingIndex] = entry;
+    }
+  }
+
+  ChildAttendanceSummary build() {
+    return ChildAttendanceSummary(
+      childId: childId,
+      childName: childName,
+      classId: classId,
+      className: className,
+      subjectEntries: List<ChildSubjectAttendance>.from(_entries),
+    );
+  }
+
+  bool _shouldReplace(
+    ChildSubjectAttendance existing,
+    ChildSubjectAttendance updated,
+  ) {
+    if (!existing.isSubmitted && updated.isSubmitted) {
+      return true;
+    }
+
+    if (existing.isSubmitted == updated.isSubmitted) {
+      if (existing.status == null && updated.status != null) {
+        return true;
+      }
+      final existingTimestamp = existing.submittedAt ?? existing.date;
+      final updatedTimestamp = updated.submittedAt ?? updated.date;
+      if (updatedTimestamp.isAfter(existingTimestamp)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  String _entryKey(ChildSubjectAttendance entry) {
+    final normalizedDate = DateTime(entry.date.year, entry.date.month, entry.date.day);
+    final dateKey = DateFormat('yyyyMMdd').format(normalizedDate);
+    final subjectKey = entry.subjectId.isNotEmpty
+        ? entry.subjectId
+        : (entry.teacherId.isNotEmpty
+            ? entry.teacherId
+            : entry.subjectLabel.toLowerCase());
+    return '$subjectKey-$dateKey';
+  }
+}

--- a/lib/modules/attendance/views/parent_child_attendance_detail_view.dart
+++ b/lib/modules/attendance/views/parent_child_attendance_detail_view.dart
@@ -2,21 +2,21 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 
 import '../../common/widgets/module_page_container.dart';
-import '../controllers/admin_attendance_controller.dart';
+import '../controllers/parent_attendance_controller.dart';
 import '../models/child_attendance_summary.dart';
 import 'widgets/child_attendance_detail_content.dart';
 
-class AdminChildAttendanceDetailView extends StatelessWidget {
-  const AdminChildAttendanceDetailView({super.key, required this.summary});
+class ParentChildAttendanceDetailView extends StatelessWidget {
+  const ParentChildAttendanceDetailView({super.key, required this.summary});
 
   final ChildAttendanceSummary summary;
 
   @override
   Widget build(BuildContext context) {
-    final controller = Get.find<AdminAttendanceController>();
+    final controller = Get.find<ParentAttendanceController>();
     return Scaffold(
       appBar: AppBar(
-        title: const Text('Student Attendance'),
+        title: const Text('Attendance Detail'),
         centerTitle: true,
       ),
       body: ModulePageContainer(
@@ -26,7 +26,8 @@ class AdminChildAttendanceDetailView extends StatelessWidget {
           return ChildAttendanceDetailContent(
             summary: summary,
             isExporting: isExporting,
-            onDownload: () => controller.exportChildAttendanceAsPdf(summary),
+            onDownload: () =>
+                controller.exportChildAttendanceAsPdf(summary),
           );
         }),
       ),

--- a/lib/modules/attendance/views/teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/teacher_attendance_view.dart
@@ -22,7 +22,10 @@ class TeacherAttendanceView extends GetView<TeacherAttendanceController> {
         leading: Obx(() {
           final selectedClass = controller.selectedClass.value;
           if (selectedClass == null) {
-            return const SizedBox.shrink();
+            return IconButton(
+              icon: const Icon(Icons.arrow_back),
+              onPressed: () => Get.back<void>(),
+            );
           }
           return IconButton(
             icon: const Icon(Icons.arrow_back),
@@ -116,36 +119,41 @@ class _TeacherClassList extends StatelessWidget {
       children: [
         Obx(() {
           final selectedDate = controller.selectedDate.value;
-          return Row(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: Text(
-                  'Attendance for ${dateFormat.format(selectedDate)}',
-                  style: theme.textTheme.titleMedium?.copyWith(
-                    fontWeight: FontWeight.w600,
+          return Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 12),
+            child: ModuleCard(
+              padding: const EdgeInsets.fromLTRB(20, 18, 20, 18),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Expanded(
+                    child: Text(
+                      'Attendance for ${dateFormat.format(selectedDate)}',
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
                   ),
-                ),
+                  TextButton.icon(
+                    onPressed: () async {
+                      final picked = await showDatePicker(
+                        context: context,
+                        initialDate: selectedDate,
+                        firstDate: DateTime(selectedDate.year - 1),
+                        lastDate: DateTime(selectedDate.year + 1),
+                      );
+                      if (picked != null) {
+                        controller.setDate(picked);
+                      }
+                    },
+                    icon: const Icon(Icons.calendar_today, size: 18),
+                    label: const Text('Change date'),
+                  ),
+                ],
               ),
-              TextButton.icon(
-                onPressed: () async {
-                  final picked = await showDatePicker(
-                    context: context,
-                    initialDate: selectedDate,
-                    firstDate: DateTime(selectedDate.year - 1),
-                    lastDate: DateTime(selectedDate.year + 1),
-                  );
-                  if (picked != null) {
-                    controller.setDate(picked);
-                  }
-                },
-                icon: const Icon(Icons.calendar_today, size: 18),
-                label: const Text('Change date'),
-              ),
-            ],
+            ),
           );
         }),
-        const SizedBox(height: 12),
         Expanded(
           child: Obx(() {
             final classes = controller.classes;

--- a/lib/modules/attendance/views/widgets/child_attendance_detail_content.dart
+++ b/lib/modules/attendance/views/widgets/child_attendance_detail_content.dart
@@ -1,0 +1,283 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../data/models/attendance_record_model.dart';
+import '../../../common/widgets/module_card.dart';
+import '../../models/child_attendance_summary.dart';
+
+class ChildAttendanceDetailContent extends StatelessWidget {
+  const ChildAttendanceDetailContent({
+    super.key,
+    required this.summary,
+    this.onDownload,
+    this.isExporting = false,
+    this.downloadLabel = 'Download PDF',
+  });
+
+  final ChildAttendanceSummary summary;
+  final VoidCallback? onDownload;
+  final bool isExporting;
+  final String downloadLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final dateFormat = DateFormat.yMMMd();
+    final pendingCount = summary.pendingCount;
+    final absentCount = summary.absentCount;
+    final presentCount = summary.presentCount;
+    return ListView(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 32),
+      children: [
+        ModuleCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  CircleAvatar(
+                    radius: 28,
+                    backgroundColor: theme.colorScheme.primary.withOpacity(0.12),
+                    child: Text(
+                      summary.childName.isNotEmpty
+                          ? summary.childName[0].toUpperCase()
+                          : '?',
+                      style: theme.textTheme.titleLarge?.copyWith(
+                        color: theme.colorScheme.primary,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ),
+                  const SizedBox(width: 16),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          summary.childName,
+                          style: theme.textTheme.titleLarge?.copyWith(
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          summary.className,
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
+                        const SizedBox(height: 12),
+                        Text(
+                          '${summary.totalSubjects} subject${summary.totalSubjects == 1 ? '' : 's'} tracked',
+                          style: theme.textTheme.bodyMedium,
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 20),
+              Wrap(
+                spacing: 10,
+                runSpacing: 10,
+                children: [
+                  if (presentCount > 0)
+                    _DetailSummaryChip(
+                      icon: Icons.check_circle,
+                      label: '$presentCount present',
+                      backgroundColor: Colors.green.shade50,
+                      foregroundColor: Colors.green.shade600,
+                    ),
+                  if (absentCount > 0)
+                    _DetailSummaryChip(
+                      icon: Icons.cancel_outlined,
+                      label: '$absentCount absent',
+                      backgroundColor:
+                          theme.colorScheme.error.withOpacity(0.12),
+                      foregroundColor: theme.colorScheme.error,
+                    ),
+                  if (pendingCount > 0)
+                    _DetailSummaryChip(
+                      icon: Icons.hourglass_empty,
+                      label: '$pendingCount pending',
+                      backgroundColor:
+                          theme.colorScheme.primary.withOpacity(0.12),
+                      foregroundColor: theme.colorScheme.primary,
+                    ),
+                ],
+              ),
+            ],
+          ),
+        ),
+        if (onDownload != null) ...[
+          const SizedBox(height: 16),
+          Align(
+            alignment: Alignment.centerLeft,
+            child: FilledButton.icon(
+              onPressed: isExporting ? null : onDownload,
+              icon: isExporting
+                  ? const SizedBox(
+                      width: 18,
+                      height: 18,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.picture_as_pdf_outlined),
+              label: Text(isExporting ? 'Preparing...' : downloadLabel),
+            ),
+          ),
+        ],
+        const SizedBox(height: 24),
+        ModuleCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Subject attendance',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 16),
+              if (summary.subjectEntries.isEmpty)
+                Text(
+                  'No attendance records are available yet.',
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                )
+              else
+                ...List.generate(summary.subjectEntries.length, (index) {
+                  final entry = summary.subjectEntries[index];
+                  final isPending = !entry.isSubmitted || entry.status == null;
+                  final status = entry.status;
+                  final Color statusColor;
+                  final String statusLabel;
+                  final IconData statusIcon;
+                  if (isPending) {
+                    statusColor =
+                        theme.colorScheme.onSurfaceVariant.withOpacity(0.8);
+                    statusLabel = 'Not submitted yet';
+                    statusIcon = Icons.hourglass_bottom;
+                  } else if (status == AttendanceStatus.present) {
+                    statusColor = Colors.green.shade600;
+                    statusLabel = 'Present';
+                    statusIcon = Icons.check_circle;
+                  } else {
+                    statusColor = theme.colorScheme.error;
+                    statusLabel = 'Absent';
+                    statusIcon = Icons.cancel_outlined;
+                  }
+
+                  return Column(
+                    children: [
+                      if (index != 0) const Divider(height: 24),
+                      Row(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            padding: const EdgeInsets.all(10),
+                            decoration: BoxDecoration(
+                              color:
+                                  theme.colorScheme.primary.withOpacity(0.12),
+                              borderRadius: BorderRadius.circular(14),
+                            ),
+                            child: Icon(
+                              Icons.book_outlined,
+                              color: theme.colorScheme.primary,
+                              size: 22,
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Text(
+                                  entry.subjectLabel,
+                                  style: theme.textTheme.titleMedium?.copyWith(
+                                    fontWeight: FontWeight.w600,
+                                  ),
+                                ),
+                                const SizedBox(height: 6),
+                                Text(
+                                  entry.teacherName,
+                                  style: theme.textTheme.bodySmall,
+                                ),
+                                const SizedBox(height: 4),
+                                Text(
+                                  dateFormat.format(entry.date),
+                                  style: theme.textTheme.bodySmall?.copyWith(
+                                    color:
+                                        theme.colorScheme.onSurfaceVariant,
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                          Column(
+                            crossAxisAlignment: CrossAxisAlignment.end,
+                            children: [
+                              Icon(statusIcon, color: statusColor, size: 22),
+                              const SizedBox(height: 6),
+                              Text(
+                                statusLabel,
+                                style: theme.textTheme.bodySmall?.copyWith(
+                                  color: statusColor,
+                                  fontWeight: FontWeight.w600,
+                                ),
+                              ),
+                            ],
+                          ),
+                        ],
+                      ),
+                    ],
+                  );
+                }),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DetailSummaryChip extends StatelessWidget {
+  const _DetailSummaryChip({
+    required this.icon,
+    required this.label,
+    required this.backgroundColor,
+    required this.foregroundColor,
+  });
+
+  final IconData icon;
+  final String label;
+  final Color backgroundColor;
+  final Color foregroundColor;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
+      decoration: BoxDecoration(
+        color: backgroundColor,
+        borderRadius: BorderRadius.circular(20),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 18, color: foregroundColor),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: foregroundColor,
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add shared child attendance summary/builder and reuse it across admin and parent flows to prevent duplicate subject entries and support PDF exports
- redesign parent attendance controller and view to list children with filters, detailed subject breakdowns, and downloadable reports
- extract reusable detail layout widget and wire PDF download buttons into admin and parent detail screens while refining teacher list header/back navigation

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d4236f6eec8331aa2d4f214c1ed436