### PR TITLE
Add missing class closing brace

### DIFF
--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -551,3 +551,4 @@ class AdminAttendanceController extends GetxController {
       isLoading.value = false;
     }
   }
+}


### PR DESCRIPTION
## Summary
- add the missing closing brace to finish the AdminAttendanceController class definition

## Testing
- flutter analyze *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d42ed572908331b1aae84f78f908d7