### PR TITLE
Improve admin attendance overview and teacher status handling

### DIFF
--- a/lib/data/models/attendance_record_model.dart
+++ b/lib/data/models/attendance_record_model.dart
@@ -1,12 +1,12 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 
-enum AttendanceStatus { present, absent }
+enum AttendanceStatus { present, absent, pending }
 
 extension AttendanceStatusParser on AttendanceStatus {
   static AttendanceStatus fromString(String? value) {
     return AttendanceStatus.values.firstWhere(
       (status) => status.name == value,
-      orElse: () => AttendanceStatus.present,
+      orElse: () => AttendanceStatus.pending,
     );
   }
 
@@ -16,6 +16,8 @@ extension AttendanceStatusParser on AttendanceStatus {
         return 'Present';
       case AttendanceStatus.absent:
         return 'Absent';
+      case AttendanceStatus.pending:
+        return 'Pending';
     }
   }
 }

--- a/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
@@ -63,18 +63,13 @@ class AdminTeacherAttendanceController extends GetxController {
     _rebuildEntries();
   }
 
-  void toggleStatus(String teacherId) {
+  void updateStatus(String teacherId, AttendanceStatus status) {
     final index = currentEntries.indexWhere((entry) => entry.teacherId == teacherId);
     if (index == -1) {
       return;
     }
     final entry = currentEntries[index];
-    final updated = entry.copyWith(
-      status: entry.status == AttendanceStatus.present
-          ? AttendanceStatus.absent
-          : AttendanceStatus.present,
-    );
-    currentEntries[index] = updated;
+    currentEntries[index] = entry.copyWith(status: status);
   }
 
   void clearFilters() {
@@ -232,7 +227,6 @@ class AdminTeacherAttendanceController extends GetxController {
               entry.teacherName,
               subjectLabelForRecord(entry),
               entry.status.label,
-              entry.note.isEmpty ? '-' : entry.note,
             ],
           )
           .toList();
@@ -252,7 +246,7 @@ class AdminTeacherAttendanceController extends GetxController {
             ),
             pw.SizedBox(height: 12),
             pw.Table.fromTextArray(
-              headers: const ['Teacher', 'Subject', 'Status', 'Note'],
+              headers: const ['Teacher', 'Subject', 'Status'],
               data: tableData,
               headerStyle: pw.TextStyle(
                 fontWeight: pw.FontWeight.bold,
@@ -264,10 +258,9 @@ class AdminTeacherAttendanceController extends GetxController {
               cellStyle: const pw.TextStyle(fontSize: 11),
               cellAlignment: pw.Alignment.centerLeft,
               columnWidths: {
-                0: const pw.FlexColumnWidth(2.3),
-                1: const pw.FlexColumnWidth(1.6),
-                2: const pw.FlexColumnWidth(1.1),
-                3: const pw.FlexColumnWidth(2),
+                0: const pw.FlexColumnWidth(2.4),
+                1: const pw.FlexColumnWidth(1.8),
+                2: const pw.FlexColumnWidth(1.2),
               },
             ),
           ],
@@ -391,7 +384,7 @@ class AdminTeacherAttendanceController extends GetxController {
         teacherName: teacher.name,
         subjectId: teacher.subjectId,
         date: DateTime(day.year, day.month, day.day),
-        status: AttendanceStatus.absent,
+        status: AttendanceStatus.pending,
         note: '',
       );
     }).toList()

--- a/lib/modules/attendance/models/child_attendance_summary.dart
+++ b/lib/modules/attendance/models/child_attendance_summary.dart
@@ -49,8 +49,12 @@ class ChildAttendanceSummary {
   int get absentCount =>
       subjectEntries.where((entry) => entry.status == AttendanceStatus.absent).length;
 
-  int get pendingCount =>
-      subjectEntries.where((entry) => entry.status == null || !entry.isSubmitted).length;
+  int get pendingCount => subjectEntries
+      .where((entry) =>
+          entry.status == null ||
+          entry.status == AttendanceStatus.pending ||
+          !entry.isSubmitted)
+      .length;
 
   int get totalSubjects => subjectEntries.length;
 }


### PR DESCRIPTION
## Summary
- add a pending state to attendance records and use it as the default for new teacher entries
- refresh the admin attendance views with overview cards, status chips, and a dropdown selector for teacher status updates
- simplify the teacher attendance PDF export by removing the note column

## Testing
- flutter analyze *(fails: `flutter` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4326dcec08331acdc7f8d044401c9