### PR TITLE
Improve attendance list interactions

### DIFF
--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -172,6 +172,13 @@ class AdminAttendanceController extends GetxController {
       classScope.add(session.classId);
     }
     if (classScope.isEmpty) {
+      for (final classModel in classes) {
+        if (classModel.id.isNotEmpty) {
+          classScope.add(classModel.id);
+        }
+      }
+    }
+    if (classScope.isEmpty) {
       childSummaries.clear();
       return;
     }

--- a/lib/modules/attendance/views/admin_teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/admin_teacher_attendance_view.dart
@@ -473,7 +473,7 @@ class _TeacherAttendanceTile extends StatelessWidget {
                   ],
                 ),
               ),
-              _StatusDropdown(
+              _StatusSelector(
                 status: entry.status,
                 onChanged: onStatusChanged,
               ),
@@ -532,8 +532,8 @@ class _FilterChip extends StatelessWidget {
   }
 }
 
-class _StatusDropdown extends StatelessWidget {
-  const _StatusDropdown({
+class _StatusSelector extends StatelessWidget {
+  const _StatusSelector({
     required this.status,
     required this.onChanged,
   });
@@ -544,42 +544,40 @@ class _StatusDropdown extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final statuses = <AttendanceStatus>[
+      AttendanceStatus.pending,
+      AttendanceStatus.present,
+      AttendanceStatus.absent,
+    ];
     return Column(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.end,
       children: [
-        DropdownButtonHideUnderline(
-          child: DecoratedBox(
-            decoration: BoxDecoration(
-              color: theme.colorScheme.surfaceVariant,
-              borderRadius: BorderRadius.circular(20),
-            ),
-            child: Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 12),
-              child: DropdownButton<AttendanceStatus>(
-                value: status,
-                borderRadius: BorderRadius.circular(16),
-                icon: const Icon(Icons.expand_more),
-                onChanged: (value) {
-                  if (value != null) {
-                    onChanged(value);
-                  }
-                },
-                items: const [
-                  AttendanceStatus.pending,
-                  AttendanceStatus.present,
-                  AttendanceStatus.absent,
-                ]
-                    .map(
-                      (status) => DropdownMenuItem<AttendanceStatus>(
-                        value: status,
-                        child: Text(status.label),
-                      ),
-                    )
-                    .toList(),
-              ),
-            ),
-          ),
+        ToggleButtons(
+          borderRadius: BorderRadius.circular(20),
+          constraints: const BoxConstraints(minHeight: 40, minWidth: 72),
+          isSelected: statuses.map((value) => value == status).toList(),
+          onPressed: (index) => onChanged(statuses[index]),
+          color: theme.colorScheme.onSurface,
+          selectedColor: theme.colorScheme.primary,
+          fillColor: theme.colorScheme.primary.withOpacity(0.12),
+          borderColor: theme.colorScheme.outline,
+          selectedBorderColor: theme.colorScheme.primary,
+          children: statuses
+              .map(
+                (value) => Padding(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 12, vertical: 4),
+                  child: Text(
+                    value.label,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontWeight:
+                          value == status ? FontWeight.w700 : FontWeight.w500,
+                    ),
+                  ),
+                ),
+              )
+              .toList(),
         ),
         const SizedBox(height: 6),
         Text(

--- a/lib/modules/attendance/views/teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/teacher_attendance_view.dart
@@ -124,7 +124,7 @@ class _TeacherClassList extends StatelessWidget {
             child: ModuleCard(
               padding: const EdgeInsets.fromLTRB(20, 18, 20, 18),
               child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                crossAxisAlignment: CrossAxisAlignment.start,
                 children: [
                   Expanded(
                     child: Text(
@@ -134,20 +134,32 @@ class _TeacherClassList extends StatelessWidget {
                       ),
                     ),
                   ),
-                  TextButton.icon(
-                    onPressed: () async {
-                      final picked = await showDatePicker(
-                        context: context,
-                        initialDate: selectedDate,
-                        firstDate: DateTime(selectedDate.year - 1),
-                        lastDate: DateTime(selectedDate.year + 1),
-                      );
-                      if (picked != null) {
-                        controller.setDate(picked);
-                      }
-                    },
-                    icon: const Icon(Icons.calendar_today, size: 18),
-                    label: const Text('Change date'),
+                  Wrap(
+                    alignment: WrapAlignment.end,
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: [
+                      OutlinedButton.icon(
+                        onPressed: () => controller.setDate(DateTime.now()),
+                        icon: const Icon(Icons.today, size: 18),
+                        label: const Text('Today'),
+                      ),
+                      TextButton.icon(
+                        onPressed: () async {
+                          final picked = await showDatePicker(
+                            context: context,
+                            initialDate: selectedDate,
+                            firstDate: DateTime(selectedDate.year - 1),
+                            lastDate: DateTime(selectedDate.year + 1),
+                          );
+                          if (picked != null) {
+                            controller.setDate(picked);
+                          }
+                        },
+                        icon: const Icon(Icons.calendar_today, size: 18),
+                        label: const Text('Change date'),
+                      ),
+                    ],
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- add a Today shortcut in the teacher attendance list header to match the admin experience
- replace the admin teacher attendance status dropdown with toggle buttons for quicker updates
- ensure the admin student attendance list shows every child even when no class sessions are available

## Testing
- flutter test *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d438e109608331a19088cb054acb1b