### PR TITLE
Adjust parent attendance date pill and remove reset

### DIFF
--- a/lib/modules/attendance/views/admin_teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/admin_teacher_attendance_view.dart
@@ -631,17 +631,6 @@ class _AttendanceToggle extends StatelessWidget {
                 fontWeight: FontWeight.w600,
               ),
             ),
-            if (!isPending) ...[
-              const SizedBox(width: 12),
-              TextButton(
-                onPressed: () => onChanged(AttendanceStatus.pending),
-                style: TextButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(horizontal: 8),
-                  minimumSize: const Size(0, 32),
-                ),
-                child: const Text('Reset'),
-              ),
-            ],
           ],
         ),
       ],

--- a/lib/modules/attendance/views/parent_attendance_view.dart
+++ b/lib/modules/attendance/views/parent_attendance_view.dart
@@ -135,15 +135,6 @@ class _ParentChildSummaryCard extends StatelessWidget {
                       '${summary.totalSubjects} subject${summary.totalSubjects == 1 ? '' : 's'} tracked',
                       style: theme.textTheme.bodySmall,
                     ),
-                    if (latestDateLabel != null) ...[
-                      const SizedBox(height: 4),
-                      Text(
-                        'Latest entry: $latestDateLabel',
-                        style: theme.textTheme.bodySmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
                   ],
                 ),
               ),
@@ -158,6 +149,14 @@ class _ParentChildSummaryCard extends StatelessWidget {
             spacing: 8,
             runSpacing: 8,
             children: [
+              if (latestDateLabel != null)
+                _AttendanceSummaryPill(
+                  backgroundColor:
+                      theme.colorScheme.secondary.withOpacity(0.12),
+                  iconColor: theme.colorScheme.secondary,
+                  icon: Icons.event,
+                  label: 'Latest: $latestDateLabel',
+                ),
               if (presentCount > 0)
                 _AttendanceSummaryPill(
                   backgroundColor: Colors.green.shade50,


### PR DESCRIPTION
## Summary
- remove the manual reset button from the teacher attendance toggle row
- style the latest attendance date in the parent child summary card with the same pill treatment as other status chips

## Testing
- dart format *(fails: `dart` not installed in environment)*
- flutter format *(fails: `flutter` not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d447751e14833190317889d47480fc