### PR TITLE
Simplify attendance date cards and update parent overview

### DIFF
--- a/lib/modules/attendance/views/parent_attendance_view.dart
+++ b/lib/modules/attendance/views/parent_attendance_view.dart
@@ -9,6 +9,7 @@ import '../../common/widgets/module_page_container.dart';
 import '../controllers/parent_attendance_controller.dart';
 import '../models/child_attendance_summary.dart';
 import 'parent_child_attendance_detail_view.dart';
+import 'widgets/attendance_date_card.dart';
 
 class ParentAttendanceView extends GetView<ParentAttendanceController> {
   const ParentAttendanceView({super.key});
@@ -26,6 +27,7 @@ class ParentAttendanceView extends GetView<ParentAttendanceController> {
         child: Column(
           children: [
             const _ParentAttendanceFilters(),
+            _ParentAttendanceOverview(dateFormat: dateFormat),
             Expanded(
               child: Obx(() {
                 if (controller.isLoading.value) {
@@ -70,6 +72,73 @@ class ParentAttendanceView extends GetView<ParentAttendanceController> {
           ],
         ),
       ),
+    );
+  }
+}
+
+class _ParentAttendanceOverview extends StatelessWidget {
+  const _ParentAttendanceOverview({required this.dateFormat});
+
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<ParentAttendanceController>();
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+      child: Obx(() {
+        final childId = controller.childFilter.value;
+        final date = controller.dateFilter.value;
+        final childModel = controller.children
+            .firstWhereOrNull((child) => child.id == childId);
+        final hasSingleChild = controller.children.length == 1;
+        final defaultChildName = controller.children.isNotEmpty
+            ? controller.children.first.name
+            : 'All children';
+        final resolvedChildName = (childId == null || childId.isEmpty)
+            ? (hasSingleChild ? defaultChildName : 'All children')
+            : (childModel?.name ?? 'Child');
+        final trimmedChildName = resolvedChildName.trim();
+        final childLabel = trimmedChildName.isEmpty
+            ? ((childId == null || childId.isEmpty)
+                ? 'All children'
+                : 'Child')
+            : trimmedChildName;
+        final dateLabel = date == null ? 'All dates' : dateFormat.format(date);
+        final summariesCount = controller.childSummaries.length;
+        final sessionsCount = controller.sessions.length;
+        final summariesLabel = summariesCount == 1 ? 'child' : 'children';
+        final sessionsLabel = sessionsCount == 1 ? 'session' : 'sessions';
+
+        return AttendanceDateCard(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                'Attendance overview',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                '$childLabel • $dateLabel',
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 12),
+              Text(
+                'Showing $summariesCount $summariesLabel across $sessionsCount $sessionsLabel.',
+                style: theme.textTheme.bodyMedium?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+            ],
+          ),
+        );
+      }),
     );
   }
 }

--- a/lib/modules/attendance/views/widgets/attendance_date_card.dart
+++ b/lib/modules/attendance/views/widgets/attendance_date_card.dart
@@ -12,58 +12,9 @@ class AttendanceDateCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final background = Color.lerp(
-      theme.colorScheme.surface,
-      theme.colorScheme.primaryContainer,
-      theme.brightness == Brightness.dark ? 0.35 : 0.75,
-    );
-    final highlight = theme.colorScheme.primary.withOpacity(
-      theme.brightness == Brightness.dark ? 0.25 : 0.18,
-    );
-    final radius = BorderRadius.circular(24);
-
-    return Container(
-      decoration: BoxDecoration(
-        borderRadius: radius,
-        color: background,
-        border: Border.all(
-          color: theme.colorScheme.primary.withOpacity(
-            theme.brightness == Brightness.dark ? 0.35 : 0.22,
-          ),
-        ),
-        boxShadow: [
-          BoxShadow(
-            color: theme.colorScheme.primary.withOpacity(
-              theme.brightness == Brightness.dark ? 0.28 : 0.14,
-            ),
-            blurRadius: 28,
-            offset: const Offset(0, 18),
-          ),
-        ],
-      ),
-      child: ClipRRect(
-        borderRadius: radius,
-        child: Stack(
-          children: [
-            Positioned.fill(
-              child: DecoratedBox(
-                decoration: BoxDecoration(
-                  gradient: LinearGradient(
-                    colors: [highlight, Colors.transparent],
-                    begin: Alignment.topLeft,
-                    end: Alignment.bottomRight,
-                  ),
-                ),
-              ),
-            ),
-            Padding(
-              padding: padding,
-              child: child,
-            ),
-          ],
-        ),
-      ),
+    return Padding(
+      padding: padding,
+      child: child,
     );
   }
 }


### PR DESCRIPTION
## Summary
- simplify the shared attendance date card widget so list headers are no longer wrapped in a decorative card
- show the parent attendance overview inside the shared date card with child/date context and record counts

## Testing
- flutter analyze *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4536417cc833194a1581dce6c4ee7