### PR TITLE
Adjust attendance summaries to honor selected date

### DIFF
--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -157,7 +157,7 @@ class AdminAttendanceController extends GetxController {
 
   void _buildChildSummaries() {
     final filterClassId = classFilter.value;
-    final targetDate = dateFilter.value;
+    final targetDate = _normalizeDate(dateFilter.value ?? DateTime.now());
     final summaries = <String, ChildAttendanceSummaryBuilder>{};
     final classesById = {for (final item in classes) item.id: item};
     final childrenById = {for (final child in children) child.id: child};
@@ -198,11 +198,13 @@ class AdminAttendanceController extends GetxController {
             childName: resolvedName,
             classId: classId,
             className: classModel.name,
+            displayDate: targetDate,
           );
         });
         builder.childName = resolvedName;
         builder.classId = classId;
         builder.className = classModel.name;
+        builder.displayDate = targetDate;
       }
     }
 
@@ -248,6 +250,7 @@ class AdminAttendanceController extends GetxController {
             childName: resolvedName,
             classId: resolvedClassId,
             className: resolvedClassName,
+            displayDate: targetDate,
           );
         });
         builder.childName = resolvedName;
@@ -255,6 +258,7 @@ class AdminAttendanceController extends GetxController {
           builder.classId = resolvedClassId;
           builder.className = resolvedClassName;
         }
+        builder.displayDate = targetDate;
 
         final record = session.records
             .firstWhereOrNull((item) => item.childId == childId);
@@ -298,8 +302,7 @@ class AdminAttendanceController extends GetxController {
       if (classChildren.isEmpty) {
         continue;
       }
-      final placeholderDate =
-          _normalizeDate(targetDate ?? DateTime.now());
+      final placeholderDate = targetDate;
 
       for (final child in classChildren) {
         if (child.id.isEmpty) continue;
@@ -311,11 +314,13 @@ class AdminAttendanceController extends GetxController {
             childName: resolvedName,
             classId: classId,
             className: classModel.name,
+            displayDate: targetDate,
           );
         });
         builder.childName = resolvedName;
         builder.classId = classId;
         builder.className = classModel.name;
+        builder.displayDate = targetDate;
 
         for (final subjectEntry in classModel.teacherSubjects.entries) {
           final subjectId = subjectEntry.key;

--- a/lib/modules/attendance/controllers/parent_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/parent_attendance_controller.dart
@@ -174,6 +174,7 @@ class ParentAttendanceController extends GetxController {
       return;
     }
 
+    final targetDate = _normalizeDate(dateFilter.value ?? DateTime.now());
     final builders = <String, ChildAttendanceSummaryBuilder>{};
     final childrenById = {for (final child in children) child.id: child};
     final classesById = {for (final item in classes) item.id: item};
@@ -208,9 +209,11 @@ class ParentAttendanceController extends GetxController {
           childName: resolvedName,
           classId: child.classId,
           className: classModel?.name ?? 'Class',
+          displayDate: targetDate,
         );
       });
       builder.childName = resolvedName;
+      builder.displayDate = targetDate;
       if (child.classId.isNotEmpty) {
         builder.classId = child.classId;
         builder.className = classModel?.name ?? builder.className;
@@ -243,9 +246,11 @@ class ParentAttendanceController extends GetxController {
             className: childModel?.classId.isNotEmpty == true
                 ? classesById[childModel!.classId]?.name ?? session.className
                 : session.className,
+            displayDate: targetDate,
           );
         });
         builder.childName = resolvedName;
+        builder.displayDate = targetDate;
         if (childModel?.classId.isNotEmpty == true) {
           builder.classId = childModel!.classId;
           builder.className =
@@ -287,7 +292,7 @@ class ParentAttendanceController extends GetxController {
     }
 
     final placeholderDate =
-        _normalizeDate(dateFilter.value ?? DateTime.now());
+        targetDate;
     for (final classId in classScope) {
       final classModel = classesById[classId];
       if (classModel == null || classModel.teacherSubjects.isEmpty) {
@@ -309,11 +314,13 @@ class ParentAttendanceController extends GetxController {
             childName: resolvedName,
             classId: classId,
             className: classModel.name,
+            displayDate: targetDate,
           );
         });
         builder.childName = resolvedName;
         builder.classId = classId;
         builder.className = classModel.name;
+        builder.displayDate = targetDate;
 
         for (final subjectEntry in classModel.teacherSubjects.entries) {
           final subjectId = subjectEntry.key;

--- a/lib/modules/attendance/models/child_attendance_summary.dart
+++ b/lib/modules/attendance/models/child_attendance_summary.dart
@@ -32,6 +32,7 @@ class ChildAttendanceSummary {
     required this.childName,
     required this.classId,
     required this.className,
+    required this.displayDate,
     required List<ChildSubjectAttendance> subjectEntries,
   }) : subjectEntries = List<ChildSubjectAttendance>.unmodifiable(
           subjectEntries..sort((a, b) => b.date.compareTo(a.date)),
@@ -41,22 +42,36 @@ class ChildAttendanceSummary {
   final String childName;
   final String classId;
   final String className;
+  final DateTime displayDate;
   final List<ChildSubjectAttendance> subjectEntries;
 
-  int get presentCount =>
-      subjectEntries.where((entry) => entry.status == AttendanceStatus.present).length;
+  Iterable<ChildSubjectAttendance> get _entriesForDisplay {
+    final normalizedDisplayDate =
+        DateTime(displayDate.year, displayDate.month, displayDate.day);
+    final filtered = subjectEntries.where(
+      (entry) => entry.date.year == normalizedDisplayDate.year &&
+          entry.date.month == normalizedDisplayDate.month &&
+          entry.date.day == normalizedDisplayDate.day,
+    );
+    return filtered.isNotEmpty ? filtered : subjectEntries;
+  }
 
-  int get absentCount =>
-      subjectEntries.where((entry) => entry.status == AttendanceStatus.absent).length;
+  int get presentCount => _entriesForDisplay
+      .where((entry) => entry.status == AttendanceStatus.present)
+      .length;
 
-  int get pendingCount => subjectEntries
+  int get absentCount => _entriesForDisplay
+      .where((entry) => entry.status == AttendanceStatus.absent)
+      .length;
+
+  int get pendingCount => _entriesForDisplay
       .where((entry) =>
           entry.status == null ||
           entry.status == AttendanceStatus.pending ||
           !entry.isSubmitted)
       .length;
 
-  int get totalSubjects => subjectEntries.length;
+  int get totalSubjects => _entriesForDisplay.length;
 }
 
 class ChildAttendanceSummaryBuilder {
@@ -65,12 +80,14 @@ class ChildAttendanceSummaryBuilder {
     required this.childName,
     required this.classId,
     required this.className,
+    required this.displayDate,
   });
 
   final String childId;
   String childName;
   String classId;
   String className;
+  DateTime displayDate;
 
   final List<ChildSubjectAttendance> _entries = <ChildSubjectAttendance>[];
   final Map<String, int> _entryIndexByKey = <String, int>{};
@@ -96,6 +113,7 @@ class ChildAttendanceSummaryBuilder {
       childName: childName,
       classId: classId,
       className: className,
+      displayDate: displayDate,
       subjectEntries: List<ChildSubjectAttendance>.from(_entries),
     );
   }


### PR DESCRIPTION
## Summary
- ensure child attendance summaries track a display date and count statuses for the selected day
- update the parent and admin attendance controllers to use the normalized target date for each summary

## Testing
- flutter test *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d48438a9bc833189bd931348fa7f80