### PR TITLE
Fix save path prompt for older file_selector versions

### DIFF
--- a/lib/core/services/pdf_downloader/pdf_downloader_io.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_io.dart
@@ -34,59 +34,20 @@ Future<String?> _resolveSavePath(String sanitizedName) async {
     return pathFromPicker;
   }
 
-  if (!Platform.isAndroid) {
-    try {
-      final directoryPath = await getDirectoryPath();
-
-      if (directoryPath != null && directoryPath.trim().isNotEmpty) {
-        return p.join(directoryPath, resolvedName);
-      }
-    } on PlatformException {
-      // Fall through to the manual resolution logic when the platform channel
-      // fails to provide a directory picker (common on some desktop platforms).
-    } on UnimplementedError {
-      final directory = await _resolveDownloadDirectory();
-      return p.join(directory.path, resolvedName);
-    } catch (_) {
-      final directory = await _resolveDownloadDirectory();
-      return p.join(directory.path, resolvedName);
-    }
-  }
-
   final directory = await _resolveDownloadDirectory();
   return p.join(directory.path, resolvedName);
 }
 
 Future<String?> _promptSavePath(String resolvedName) async {
   try {
-    final selectedPath = await getSavePath(
-      suggestedName: resolvedName,
-      confirmButtonText: 'Save',
-      acceptedTypeGroups: const [
-        XTypeGroup(
-          label: 'PDF',
-          extensions: ['pdf'],
-        ),
-      ],
-    );
+    final directoryPath = await getDirectoryPath();
 
-    if (selectedPath == null || selectedPath.trim().isEmpty) {
+    if (directoryPath == null || directoryPath.trim().isEmpty) {
       return null;
     }
 
-    final normalized = selectedPath.trim();
-    if (normalized.toLowerCase().endsWith('.pdf')) {
-      return normalized;
-    }
-
-    final extension = p.extension(normalized);
-    if (extension.isEmpty) {
-      return '$normalized.pdf';
-    }
-
-    // If the user selects a non-pdf extension, replace it to ensure the file
-    // is saved as a PDF.
-    return '${normalized.substring(0, normalized.length - extension.length)}.pdf';
+    final normalizedDirectory = directoryPath.trim();
+    return p.join(normalizedDirectory, resolvedName);
   } on PlatformException {
     // Some platforms (notably older Android versions) may throw when the
     // platform picker is not available. In that case we fall back to the


### PR DESCRIPTION
## Summary
- replace the usage of the unavailable `getSavePath` API with a directory picker fallback
- simplify save path resolution by relying on the existing download directory fallback

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d48a65da188331ba6f2a66a8ad0a14