### PR TITLE
Improve storage permission handling

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,8 @@
     <application
         android:label="EduMS"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:requestLegacyExternalStorage="true">
         <activity
             android:name=".MainActivity"
             android:exported="true"


### PR DESCRIPTION
## Summary
- add legacy external storage request flag to the Android manifest so Android 10 devices keep full file access behaviour
- strengthen the PDF downloader storage permission flow by re-checking permission status and routing the user to system settings when all-files access is permanently denied

## Testing
- flutter test *(fails: `flutter` command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d48f88bc648331a39a79f5500455a5