### PR TITLE
Handle PDF save directory selection gracefully

### DIFF
--- a/lib/core/services/pdf_downloader/pdf_downloader_io.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_io.dart
@@ -25,41 +25,56 @@ Future<int?> _androidSdkInt() async {
   return _cachedAndroidSdkInt;
 }
 
+class _SavePathResult {
+  const _SavePathResult(this.path, {this.requiresStoragePermission = false});
+
+  final String path;
+  final bool requiresStoragePermission;
+}
+
 Future<String?> savePdf(Uint8List bytes, String fileName) async {
   final sanitizedName = fileName.trim().isEmpty ? 'document.pdf' : fileName;
 
-  if (Platform.isAndroid && !await _ensureStoragePermission()) {
+  final target = await _resolveSavePath(sanitizedName);
+  if (target == null) {
     return null;
   }
 
-  final targetPath = await _resolveSavePath(sanitizedName);
-  if (targetPath == null) {
+  if (target.requiresStoragePermission &&
+      Platform.isAndroid &&
+      !await _ensureStoragePermission()) {
     return null;
   }
 
-  final file = File(targetPath);
+  final file = File(target.path);
   await file.parent.create(recursive: true);
   await file.writeAsBytes(bytes, flush: true);
   return file.path;
 }
 
-Future<String?> _resolveSavePath(String sanitizedName) async {
+Future<_SavePathResult?> _resolveSavePath(String sanitizedName) async {
   final resolvedName = sanitizedName.toLowerCase().endsWith('.pdf')
       ? sanitizedName
       : '$sanitizedName.pdf';
 
   final pathFromPicker = await _promptSavePath(resolvedName);
   if (pathFromPicker != null) {
-    return pathFromPicker;
+    return _SavePathResult(pathFromPicker);
   }
 
   final directory = await _resolveDownloadDirectory();
-  return p.join(directory.path, resolvedName);
+  final fallbackPath = p.join(directory.path, resolvedName);
+  return _SavePathResult(
+    fallbackPath,
+    requiresStoragePermission: Platform.isAndroid,
+  );
 }
 
 Future<String?> _promptSavePath(String resolvedName) async {
   try {
-    final directoryPath = await getDirectoryPath();
+    final directoryPath = await getDirectoryPath(
+      confirmButtonText: 'Save PDF',
+    );
 
     if (directoryPath == null || directoryPath.trim().isEmpty) {
       return null;


### PR DESCRIPTION
## Summary
- prompt users with a directory picker labelled "Save PDF" before falling back to the download directory
- track whether the chosen save location requires Android storage permissions and request them only when needed

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68d496fd983c8331ba0e32da9a8caf45