### PR TITLE
Fix PDF downloader directory selection

### DIFF
--- a/lib/core/services/pdf_downloader/pdf_downloader_io.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_io.dart
@@ -72,6 +72,7 @@ Future<_SavePathResult?> _resolveSavePath(String sanitizedName) async {
 
 Future<String?> _promptSavePath(String resolvedName) async {
   try {
+    final directoryPath = await getDirectoryPath();
 
     if (directoryPath == null || directoryPath.trim().isEmpty) {
       return null;


### PR DESCRIPTION
## Summary
- ensure the save path prompt resolves the chosen directory before validation

## Testing
- flutter analyze *(fails: flutter command is unavailable in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d499c12b3883319e2275cb2af7e774