### PR TITLE
Handle PDF download cancellation without storage permission prompts

### DIFF
--- a/lib/core/services/pdf_downloader/pdf_download_result.dart
+++ b/lib/core/services/pdf_downloader/pdf_download_result.dart
@@ -1,0 +1,23 @@
+class PdfDownloadResult {
+  const PdfDownloadResult._({
+    required this.wasSuccessful,
+    this.path,
+    this.wasCancelled = false,
+  });
+
+  final bool wasSuccessful;
+  final String? path;
+  final bool wasCancelled;
+
+  static PdfDownloadResult saved(String path) =>
+      PdfDownloadResult._(wasSuccessful: true, path: path);
+
+  static const PdfDownloadResult triggeredDownload =
+      PdfDownloadResult._(wasSuccessful: true);
+
+  static const PdfDownloadResult cancelled =
+      PdfDownloadResult._(wasSuccessful: false, wasCancelled: true);
+
+  static const PdfDownloadResult failed =
+      PdfDownloadResult._(wasSuccessful: false);
+}

--- a/lib/core/services/pdf_downloader/pdf_downloader.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader.dart
@@ -1,14 +1,17 @@
 import 'dart:typed_data';
 
+import 'pdf_download_result.dart';
 import 'pdf_downloader_stub.dart'
     if (dart.library.html) 'pdf_downloader_web.dart'
     if (dart.library.io) 'pdf_downloader_io.dart' as downloader;
+
+export 'pdf_download_result.dart';
 
 /// Saves a PDF to an appropriate download location for the current platform.
 ///
 /// Returns the path of the saved file when it can be determined (mainly on
 /// IO-based platforms). Web platforms trigger a browser download and return
 /// `null` because no local file path is available.
-Future<String?> savePdf(Uint8List bytes, String fileName) {
+Future<PdfDownloadResult> savePdf(Uint8List bytes, String fileName) {
   return downloader.savePdf(bytes, fileName);
 }

--- a/lib/core/services/pdf_downloader/pdf_downloader_stub.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_stub.dart
@@ -1,5 +1,7 @@
 import 'dart:typed_data';
 
-Future<String?> savePdf(Uint8List bytes, String fileName) async {
+import 'pdf_download_result.dart';
+
+Future<PdfDownloadResult> savePdf(Uint8List bytes, String fileName) async {
   throw UnsupportedError('PDF downloading is not supported on this platform');
 }

--- a/lib/core/services/pdf_downloader/pdf_downloader_web.dart
+++ b/lib/core/services/pdf_downloader/pdf_downloader_web.dart
@@ -2,7 +2,9 @@
 import 'dart:html' as html;
 import 'dart:typed_data';
 
-Future<String?> savePdf(Uint8List bytes, String fileName) async {
+import 'pdf_download_result.dart';
+
+Future<PdfDownloadResult> savePdf(Uint8List bytes, String fileName) async {
   final sanitizedName = fileName.trim().isEmpty ? 'document.pdf' : fileName;
   final blob = html.Blob([bytes], 'application/pdf');
   final url = html.Url.createObjectUrlFromBlob(blob);
@@ -15,5 +17,5 @@ Future<String?> savePdf(Uint8List bytes, String fileName) async {
   anchor.remove();
   html.Url.revokeObjectUrl(url);
 
-  return null;
+  return PdfDownloadResult.triggeredDownload;
 }

--- a/lib/modules/announcement/views/announcement_detail_view.dart
+++ b/lib/modules/announcement/views/announcement_detail_view.dart
@@ -495,12 +495,17 @@ class AnnouncementDetailView extends StatelessWidget {
       final sanitized = _sanitizeFileName(announcement.title);
       final fileName =
           sanitized.isEmpty ? 'announcement.pdf' : '$sanitized.pdf';
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download ready',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -458,12 +458,17 @@ class AdminAttendanceController extends GetxController {
       final fileName =
           'attendance-${sanitizedChild.isEmpty ? 'student' : sanitizedChild}-${sanitizedClass.isEmpty ? 'class' : sanitizedClass}-$dateStamp.pdf';
       final bytes = await doc.save();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_teacher_attendance_controller.dart
@@ -278,12 +278,17 @@ class AdminTeacherAttendanceController extends GetxController {
       final fileName =
           'teacher-attendance-${DateFormat('yyyyMMdd').format(selectedDate.value)}.pdf';
       final bytes = await doc.save();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/attendance/controllers/parent_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/parent_attendance_controller.dart
@@ -465,12 +465,17 @@ class ParentAttendanceController extends GetxController {
       final fileName =
           'attendance-${sanitizedChild.isEmpty ? 'student' : sanitizedChild}-${sanitizedClass.isEmpty ? 'class' : sanitizedClass}-$dateStamp.pdf';
       final bytes = await doc.save();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/attendance/controllers/teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/teacher_attendance_controller.dart
@@ -313,12 +313,17 @@ class TeacherAttendanceController extends GetxController {
       final fileName =
           'attendance-${sanitizedClass.isEmpty ? 'class' : sanitizedClass}-${DateFormat('yyyyMMdd').format(date)}.pdf';
       final bytes = await doc.save();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/courses/views/course_detail_view.dart
+++ b/lib/modules/courses/views/course_detail_view.dart
@@ -365,12 +365,17 @@ class CourseDetailView extends StatelessWidget {
     try {
       final bytes = await doc.save();
       final fileName = _pdfFileName();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );

--- a/lib/modules/homework/views/homework_detail_view.dart
+++ b/lib/modules/homework/views/homework_detail_view.dart
@@ -993,12 +993,17 @@ class _HomeworkDetailViewState extends State<HomeworkDetailView> {
     try {
       final bytes = await doc.save();
       final fileName = _pdfFileName();
-      final savedPath = await savePdf(bytes, fileName);
+      final result = await savePdf(bytes, fileName);
       Get.closeCurrentSnackbar();
+      if (result.wasCancelled) {
+        return;
+      }
       Get.snackbar(
         'Download complete',
-        savedPath != null
-            ? 'Saved to $savedPath'
+        result.wasSuccessful
+            ? (result.path != null
+                ? 'Saved to ${result.path}'
+                : 'The download has started.')
             : 'The PDF was not saved. Please check storage permissions or try again.',
         snackPosition: SnackPosition.BOTTOM,
       );


### PR DESCRIPTION
## Summary
- add a shared PdfDownloadResult to differentiate success, cancellation, and failure states
- adjust the IO downloader to stop requesting storage access when the user cancels and reuse the picker when available
- update feature screens to respect cancellation and keep legacy fallback behaviour for older devices

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d49baaf0848331b1e7c78d12c14d48