### PR TITLE
Revamp pickup queue flows and detail experience

### DIFF
--- a/lib/data/models/pickup_model.dart
+++ b/lib/data/models/pickup_model.dart
@@ -98,16 +98,23 @@ class PickupTicketModel {
   bool get isAwaitingParent => parentConfirmedAt == null;
 
   bool get isAwaitingTeacher =>
-      parentConfirmedAt != null && teacherValidatedAt == null;
+      !isArchived && parentConfirmedAt != null && teacherValidatedAt == null;
 
   bool get isAwaitingAdmin =>
-      teacherValidatedAt != null && adminValidatedAt == null;
+      !isArchived && teacherValidatedAt != null && adminValidatedAt == null;
 
-  bool get isCompleted => adminValidatedAt != null;
+  bool get isCompleted => isArchived;
 
   bool get isArchived => archivedAt != null;
 
+  bool get releasedByTeacher => teacherValidatedAt != null;
+
+  bool get releasedByAdmin => adminValidatedAt != null;
+
   PickupStage get stage {
+    if (isArchived) {
+      return PickupStage.completed;
+    }
     if (isCompleted) {
       return PickupStage.completed;
     }

--- a/lib/modules/pickup/controllers/parent_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/parent_pickup_controller.dart
@@ -192,9 +192,6 @@ class ParentPickupController extends GetxController {
       if (ticket.parentId != parentId) {
         return false;
       }
-      if (ticket.isArchived) {
-        return false;
-      }
       final validated =
           ticket.teacherValidatedAt != null || ticket.adminValidatedAt != null;
       if (!validated) {

--- a/lib/modules/pickup/controllers/teacher_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/teacher_pickup_controller.dart
@@ -93,17 +93,24 @@ class TeacherPickupController extends GetxController {
       if (!teacherClassIds.contains(ticket.classId)) {
         return false;
       }
-      final matchesClass = classId == null || classId.isEmpty
-          ? true
-          : ticket.classId == classId;
-      final requiresTeacher =
-          ticket.stage == PickupStage.awaitingTeacher ||
-              ticket.stage == PickupStage.awaitingAdmin ||
-              ticket.stage == PickupStage.completed;
-      return matchesClass && requiresTeacher;
+      if (ticket.stage != PickupStage.awaitingTeacher) {
+        return false;
+      }
+      if (classId != null && classId.isNotEmpty && ticket.classId != classId) {
+        return false;
+      }
+      return true;
     }).toList()
-      ..sort((a, b) => a.stage.index.compareTo(b.stage.index));
+      ..sort((a, b) {
+        final aTime = _ticketSortTime(a);
+        final bTime = _ticketSortTime(b);
+        return bTime.compareTo(aTime);
+      });
     tickets.assignAll(filtered);
+  }
+
+  DateTime _ticketSortTime(PickupTicketModel ticket) {
+    return ticket.parentConfirmedAt ?? ticket.createdAt;
   }
 
   void validatePickup(PickupTicketModel ticket) {

--- a/lib/modules/pickup/views/admin_archived_pickup_view.dart
+++ b/lib/modules/pickup/views/admin_archived_pickup_view.dart
@@ -7,6 +7,7 @@ import '../../common/widgets/module_empty_state.dart';
 import '../../common/widgets/module_page_container.dart';
 import '../../attendance/views/widgets/attendance_date_card.dart';
 import '../controllers/admin_archived_pickup_controller.dart';
+import 'pickup_ticket_detail_view.dart';
 
 class AdminArchivedPickupView extends GetView<AdminArchivedPickupController> {
   const AdminArchivedPickupView({super.key});
@@ -60,99 +61,122 @@ class AdminArchivedPickupView extends GetView<AdminArchivedPickupController> {
                             final parentTime = ticket.parentConfirmedAt;
                             final teacherTime = ticket.teacherValidatedAt;
                             return AttendanceDateCard(
-                              child: Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  Row(
-                                    crossAxisAlignment: CrossAxisAlignment.start,
-                                    children: [
-                                      Expanded(
-                                        child: Column(
+                              child: Material(
+                                color: Colors.transparent,
+                                child: InkWell(
+                                  borderRadius: BorderRadius.circular(24),
+                                  onTap: () => Get.to(
+                                    () => PickupTicketDetailView(ticket: ticket),
+                                  ),
+                                  child: Padding(
+                                    padding: const EdgeInsets.only(top: 4, bottom: 4),
+                                    child: Column(
+                                      crossAxisAlignment: CrossAxisAlignment.start,
+                                      children: [
+                                        Row(
                                           crossAxisAlignment: CrossAxisAlignment.start,
                                           children: [
-                                            Text(
-                                              ticket.childName,
-                                              style: Theme.of(context)
-                                                  .textTheme
-                                                  .titleMedium
-                                                  ?.copyWith(
-                                                    fontWeight: FontWeight.w700,
+                                            Expanded(
+                                              child: Column(
+                                                crossAxisAlignment: CrossAxisAlignment.start,
+                                                children: [
+                                                  Text(
+                                                    ticket.childName,
+                                                    style: Theme.of(context)
+                                                        .textTheme
+                                                        .titleMedium
+                                                        ?.copyWith(
+                                                          fontWeight: FontWeight.w700,
+                                                        ),
                                                   ),
+                                                  const SizedBox(height: 6),
+                                                  Text(
+                                                    '${controller.className(ticket.classId)} • ${ticket.parentName}',
+                                                    style: Theme.of(context)
+                                                        .textTheme
+                                                        .bodySmall
+                                                        ?.copyWith(
+                                                          color: Theme.of(context)
+                                                              .colorScheme
+                                                              .onSurfaceVariant,
+                                                        ),
+                                                  ),
+                                                ],
+                                              ),
                                             ),
-                                            const SizedBox(height: 4),
-                                            Text(
-                                              '${controller.className(ticket.classId)} • ${ticket.parentName}',
-                                              style: Theme.of(context)
-                                                  .textTheme
-                                                  .bodySmall
-                                                  ?.copyWith(
-                                                    color: Theme.of(context)
-                                                        .colorScheme
-                                                        .onSurfaceVariant,
-                                                  ),
+                                            Column(
+                                              crossAxisAlignment: CrossAxisAlignment.end,
+                                              children: [
+                                                Text(
+                                                  dateFormat.format(archivedAt),
+                                                  style: Theme.of(context)
+                                                      .textTheme
+                                                      .titleSmall
+                                                      ?.copyWith(
+                                                        fontWeight: FontWeight.w600,
+                                                      ),
+                                                ),
+                                                const SizedBox(height: 4),
+                                                Text(
+                                                  timeFormat.format(archivedAt),
+                                                  style: Theme.of(context)
+                                                      .textTheme
+                                                      .bodySmall
+                                                      ?.copyWith(
+                                                        color: Theme.of(context)
+                                                            .colorScheme
+                                                            .primary,
+                                                      ),
+                                                ),
+                                              ],
                                             ),
                                           ],
                                         ),
-                                      ),
-                                      Column(
-                                        crossAxisAlignment: CrossAxisAlignment.end,
-                                        children: [
-                                          Text(
-                                            dateFormat.format(archivedAt),
-                                            style: Theme.of(context)
-                                                .textTheme
-                                                .titleSmall
-                                                ?.copyWith(
-                                                  fontWeight: FontWeight.w600,
-                                                ),
+                                        const SizedBox(height: 16),
+                                        Wrap(
+                                          spacing: 12,
+                                          runSpacing: 12,
+                                          children: [
+                                            _ArchiveInfoChip(
+                                              icon: Icons.access_time,
+                                              label:
+                                                  'Created: ${archivedFormat.format(ticket.createdAt)}',
+                                            ),
+                                            if (parentTime != null)
+                                              _ArchiveInfoChip(
+                                                icon: Icons.check_circle_outline,
+                                                label:
+                                                    'Parent confirmed: ${archivedFormat.format(parentTime)}',
+                                              ),
+                                            if (teacherTime != null)
+                                              _ArchiveInfoChip(
+                                                icon: Icons.verified_outlined,
+                                                label:
+                                                    'Teacher validated: ${archivedFormat.format(teacherTime)}',
+                                              ),
+                                            if (ticket.adminValidatedAt != null)
+                                              _ArchiveInfoChip(
+                                                icon: Icons.admin_panel_settings_outlined,
+                                                label:
+                                                    'Admin released: ${archivedFormat.format(ticket.adminValidatedAt!)}',
+                                              ),
+                                          ],
+                                        ),
+                                        const SizedBox(height: 16),
+                                        Align(
+                                          alignment: Alignment.centerRight,
+                                          child: TextButton.icon(
+                                            onPressed: () => Get.to(
+                                              () => PickupTicketDetailView(ticket: ticket),
+                                            ),
+                                            icon: const Icon(Icons.visibility_outlined, size: 18),
+                                            label: const Text('View details'),
                                           ),
-                                          const SizedBox(height: 4),
-                                          Text(
-                                            timeFormat.format(archivedAt),
-                                            style: Theme.of(context)
-                                                .textTheme
-                                                .bodySmall
-                                                ?.copyWith(
-                                                  color: Theme.of(context)
-                                                      .colorScheme
-                                                      .primary,
-                                                ),
-                                          ),
-                                        ],
-                                      ),
-                                    ],
+                                        ),
+                                      ],
+                                    ),
                                   ),
-                                  const SizedBox(height: 16),
-                                  Wrap(
-                                    spacing: 12,
-                                    runSpacing: 12,
-                                    children: [
-                                      _ArchiveInfoChip(
-                                        icon: Icons.access_time,
-                                        label:
-                                            'Created: ${archivedFormat.format(ticket.createdAt)}',
-                                      ),
-                                      if (parentTime != null)
-                                        _ArchiveInfoChip(
-                                          icon: Icons.check_circle_outline,
-                                          label:
-                                              'Parent confirmed: ${archivedFormat.format(parentTime)}',
-                                        ),
-                                      if (teacherTime != null)
-                                        _ArchiveInfoChip(
-                                          icon: Icons.verified_outlined,
-                                          label:
-                                              'Teacher validated: ${archivedFormat.format(teacherTime)}',
-                                        ),
-                                      if (ticket.adminValidatedAt != null)
-                                        _ArchiveInfoChip(
-                                          icon: Icons.admin_panel_settings_outlined,
-                                          label:
-                                              'Admin released: ${archivedFormat.format(ticket.adminValidatedAt!)}',
-                                        ),
-                                    ],
-                                  ),
-                                ],
+                                ),
                               ),
                             );
                           },

--- a/lib/modules/pickup/views/pickup_ticket_detail_view.dart
+++ b/lib/modules/pickup/views/pickup_ticket_detail_view.dart
@@ -1,0 +1,628 @@
+import 'package:characters/characters.dart';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:intl/intl.dart';
+
+import '../../../core/services/database_service.dart';
+import '../../../data/models/admin_model.dart';
+import '../../../data/models/pickup_model.dart';
+import '../../../data/models/subject_model.dart';
+import '../../../data/models/teacher_model.dart';
+import '../../common/widgets/module_card.dart';
+
+class PickupTicketDetailView extends StatelessWidget {
+  PickupTicketDetailView({
+    super.key,
+    required this.ticket,
+  });
+
+  final PickupTicketModel ticket;
+
+  final DateFormat _dateFormat = DateFormat('MMM d, yyyy • h:mm a');
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Pickup detail'),
+        centerTitle: true,
+      ),
+      body: FutureBuilder<_PickupDetailData>(
+        future: _loadDetails(),
+        builder: (context, snapshot) {
+          if (snapshot.connectionState == ConnectionState.waiting) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          if (snapshot.hasError) {
+            return Center(
+              child: Padding(
+                padding: const EdgeInsets.all(24),
+                child: Text(
+                  'We were unable to load the pickup detail.\n${snapshot.error}',
+                  textAlign: TextAlign.center,
+                  style: theme.textTheme.bodyMedium,
+                ),
+              ),
+            );
+          }
+          final detail = snapshot.data ?? const _PickupDetailData();
+          return SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                _buildHeroHeader(context, detail),
+                const SizedBox(height: 24),
+                _buildTimelineCard(context),
+                if (detail.teacher != null || detail.admin != null) ...[
+                  const SizedBox(height: 24),
+                  _buildValidatorCard(context, detail),
+                ],
+                const SizedBox(height: 24),
+                _buildMetadataCard(context, detail),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Future<_PickupDetailData> _loadDetails() async {
+    final db = Get.find<DatabaseService>();
+    TeacherModel? teacher;
+    SubjectModel? subject;
+    AdminModel? admin;
+
+    try {
+      if (ticket.teacherValidatorId.isNotEmpty) {
+        final teacherSnap = await db.firestore
+            .collection('teachers')
+            .doc(ticket.teacherValidatorId)
+            .get();
+        if (teacherSnap.exists) {
+          teacher = TeacherModel.fromDoc(teacherSnap);
+          if (teacher!.subjectId.isNotEmpty) {
+            final subjectSnap = await db.firestore
+                .collection('subjects')
+                .doc(teacher!.subjectId)
+                .get();
+            if (subjectSnap.exists) {
+              subject = SubjectModel.fromDoc(subjectSnap);
+            }
+          }
+        }
+      }
+
+      if (ticket.adminValidatorId.isNotEmpty) {
+        final adminSnap = await db.firestore
+            .collection('admins')
+            .doc(ticket.adminValidatorId)
+            .get();
+        if (adminSnap.exists) {
+          admin = AdminModel.fromFirestore(adminSnap);
+        }
+      }
+    } catch (error) {
+      return Future.error(error);
+    }
+
+    return _PickupDetailData(
+      teacher: teacher,
+      subject: subject,
+      admin: admin,
+    );
+  }
+
+  Widget _buildHeroHeader(BuildContext context, _PickupDetailData detail) {
+    final theme = Theme.of(context);
+    final primary = theme.colorScheme.primary;
+    final gradientStart = Color.lerp(primary, Colors.white, 0.08)!;
+    final gradientEnd = Color.lerp(primary, Colors.black, 0.18)!;
+    final stageLabel = _stageHeadline();
+
+    return Container(
+      width: double.infinity,
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          colors: [gradientStart, gradientEnd],
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+        ),
+        borderRadius: BorderRadius.circular(28),
+        boxShadow: [
+          BoxShadow(
+            color: primary.withOpacity(0.28),
+            blurRadius: 22,
+            offset: const Offset(0, 16),
+          ),
+        ],
+      ),
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              CircleAvatar(
+                radius: 36,
+                backgroundColor: Colors.white.withOpacity(0.18),
+                child: Text(
+                  _initialsFor(ticket.childName),
+                  style: theme.textTheme.headlineSmall?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+              const SizedBox(width: 18),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      ticket.childName.trim().isEmpty
+                          ? 'Student'
+                          : ticket.childName,
+                      style: theme.textTheme.headlineSmall?.copyWith(
+                        color: Colors.white,
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      stageLabel,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        color: Colors.white.withOpacity(0.85),
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 20),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _heroChip(
+                context,
+                icon: Icons.class_outlined,
+                label: ticket.className.trim().isEmpty
+                    ? 'Class not set'
+                    : ticket.className,
+              ),
+              _heroChip(
+                context,
+                icon: Icons.family_restroom_outlined,
+                label: ticket.parentName.trim().isEmpty
+                    ? 'Parent not recorded'
+                    : 'Parent: ${ticket.parentName}',
+              ),
+              _heroChip(
+                context,
+                icon: Icons.schedule,
+                label: 'Created ${_dateFormat.format(ticket.createdAt)}',
+              ),
+              if (detail.teacher != null)
+                _heroChip(
+                  context,
+                  icon: Icons.school_outlined,
+                  label: 'Teacher: ${detail.teacher!.name}',
+                ),
+              if (detail.admin != null)
+                _heroChip(
+                  context,
+                  icon: Icons.admin_panel_settings_outlined,
+                  label: 'Admin: ${detail.admin!.name}',
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTimelineCard(BuildContext context) {
+    final theme = Theme.of(context);
+    final events = <_TimelineEvent>[
+      _TimelineEvent(
+        icon: Icons.schedule,
+        label: 'Ticket created',
+        timestamp: ticket.createdAt,
+      ),
+    ];
+
+    if (ticket.parentConfirmedAt != null) {
+      events.add(
+        _TimelineEvent(
+          icon: Icons.directions_walk,
+          label: 'Parent arrived at school',
+          timestamp: ticket.parentConfirmedAt!,
+        ),
+      );
+    }
+
+    if (ticket.teacherValidatedAt != null) {
+      events.add(
+        _TimelineEvent(
+          icon: Icons.verified_outlined,
+          label: 'Teacher released student',
+          timestamp: ticket.teacherValidatedAt!,
+        ),
+      );
+    }
+
+    if (ticket.adminValidatedAt != null) {
+      events.add(
+        _TimelineEvent(
+          icon: Icons.task_alt_outlined,
+          label: 'Admin released student',
+          timestamp: ticket.adminValidatedAt!,
+        ),
+      );
+    }
+
+    if (ticket.archivedAt != null) {
+      events.add(
+        _TimelineEvent(
+          icon: Icons.archive_outlined,
+          label: 'Ticket archived',
+          timestamp: ticket.archivedAt!,
+        ),
+      );
+    }
+
+    return ModuleCard(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Timeline',
+            style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 12),
+          ...events.map((event) => _TimelineTile(
+                event: event,
+                dateFormat: _dateFormat,
+              )),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildValidatorCard(
+    BuildContext context,
+    _PickupDetailData detail,
+  ) {
+    final theme = Theme.of(context);
+    final entries = <Widget>[];
+
+    if (detail.teacher != null) {
+      entries.add(
+        _validatorTile(
+          context,
+          title: 'Teacher validation',
+          icon: Icons.verified_outlined,
+          name: detail.teacher!.name,
+          email: detail.teacher!.email,
+          subtitle: detail.subject == null
+              ? 'Subject not assigned'
+              : 'Subject: ${detail.subject!.name}',
+          timestamp: ticket.teacherValidatedAt,
+        ),
+      );
+    }
+
+    if (detail.admin != null) {
+      if (entries.isNotEmpty) {
+        entries.add(const Divider(height: 24));
+      }
+      entries.add(
+        _validatorTile(
+          context,
+          title: 'Admin validation',
+          icon: Icons.admin_panel_settings_outlined,
+          name: detail.admin!.name,
+          email: detail.admin!.email,
+          subtitle: 'Administrator',
+          timestamp: ticket.adminValidatedAt,
+        ),
+      );
+    }
+
+    return ModuleCard(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Validation overview',
+            style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 12),
+          ...entries,
+        ],
+      ),
+    );
+  }
+
+  Widget _validatorTile(
+    BuildContext context, {
+    required String title,
+    required IconData icon,
+    required String name,
+    required String email,
+    required String subtitle,
+    required DateTime? timestamp,
+  }) {
+    final theme = Theme.of(context);
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Container(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primary.withOpacity(0.1),
+            borderRadius: BorderRadius.circular(12),
+          ),
+          padding: const EdgeInsets.all(12),
+          child: Icon(icon, color: theme.colorScheme.primary),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: theme.textTheme.labelLarge?.copyWith(
+                      fontWeight: FontWeight.w600,
+                    ),
+              ),
+              const SizedBox(height: 8),
+              Text(
+                name.isEmpty ? 'Name unavailable' : name,
+                style: theme.textTheme.titleMedium,
+              ),
+              const SizedBox(height: 4),
+              Text(
+                email.isEmpty ? 'Email unavailable' : email,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: theme.colorScheme.onSurfaceVariant,
+                ),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: theme.textTheme.bodySmall,
+              ),
+              if (timestamp != null) ...[
+                const SizedBox(height: 4),
+                Text(
+                  _dateFormat.format(timestamp),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.primary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildMetadataCard(
+    BuildContext context,
+    _PickupDetailData detail,
+  ) {
+    final theme = Theme.of(context);
+    final statusLabel = ticket.isArchived ? 'Archived' : _stageHeadline();
+
+    return ModuleCard(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Pickup summary',
+            style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+          ),
+          const SizedBox(height: 12),
+          Wrap(
+            spacing: 12,
+            runSpacing: 12,
+            children: [
+              _metadataChip(
+                context,
+                icon: Icons.badge_outlined,
+                label: 'Ticket ID: ${ticket.id}',
+              ),
+              _metadataChip(
+                context,
+                icon: Icons.people_outline,
+                label: 'Parent: ${ticket.parentName}',
+              ),
+              _metadataChip(
+                context,
+                icon: Icons.child_care_outlined,
+                label: 'Child ID: ${ticket.childId}',
+              ),
+              _metadataChip(
+                context,
+                icon: Icons.info_outline,
+                label: statusLabel,
+              ),
+              if (ticket.archivedAt != null)
+                _metadataChip(
+                  context,
+                  icon: Icons.archive_outlined,
+                  label: 'Archived ${_dateFormat.format(ticket.archivedAt!)}',
+                ),
+              if (detail.teacher != null && detail.subject != null)
+                _metadataChip(
+                  context,
+                  icon: Icons.menu_book_outlined,
+                  label: 'Subject: ${detail.subject!.name}',
+                ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _heroChip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+  }) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(icon, size: 18, color: Colors.white),
+      label: Text(label),
+      backgroundColor: Colors.white.withOpacity(0.15),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(18)),
+      labelStyle: theme.textTheme.bodyMedium?.copyWith(
+        color: Colors.white,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  Widget _metadataChip(
+    BuildContext context, {
+    required IconData icon,
+    required String label,
+  }) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(icon, size: 18, color: theme.colorScheme.primary),
+      label: Text(label),
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      labelStyle: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.primary,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+
+  String _stageHeadline() {
+    if (ticket.releasedByTeacher) {
+      return 'Released by ${ticket.teacherValidatorName.isEmpty ? 'teacher' : ticket.teacherValidatorName}';
+    }
+    if (ticket.releasedByAdmin) {
+      return 'Released by ${ticket.adminValidatorName.isEmpty ? 'admin' : ticket.adminValidatorName}';
+    }
+    if (ticket.isAwaitingTeacher) {
+      return 'Waiting for release';
+    }
+    if (ticket.isAwaitingParent) {
+      return 'Waiting for parent';
+    }
+    return 'Pickup in progress';
+  }
+
+  String _initialsFor(String input) {
+    final normalized = input.trim();
+    if (normalized.isEmpty) {
+      return 'ST';
+    }
+    final parts = normalized.split(' ');
+    if (parts.length == 1) {
+      return normalized.characters.take(2).toUpperCase();
+    }
+    final first = parts.first.characters.first;
+    final last = parts.last.characters.first;
+    return (first + last).toUpperCase();
+  }
+}
+
+class _PickupDetailData {
+  const _PickupDetailData({
+    this.teacher,
+    this.subject,
+    this.admin,
+  });
+
+  final TeacherModel? teacher;
+  final SubjectModel? subject;
+  final AdminModel? admin;
+}
+
+class _TimelineEvent {
+  const _TimelineEvent({
+    required this.icon,
+    required this.label,
+    required this.timestamp,
+  });
+
+  final IconData icon;
+  final String label;
+  final DateTime timestamp;
+}
+
+class _TimelineTile extends StatelessWidget {
+  const _TimelineTile({
+    required this.event,
+    required this.dateFormat,
+  });
+
+  final _TimelineEvent event;
+  final DateFormat dateFormat;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Container(
+            decoration: BoxDecoration(
+              color: theme.colorScheme.primary.withOpacity(0.1),
+              shape: BoxShape.circle,
+            ),
+            padding: const EdgeInsets.all(12),
+            child: Icon(event.icon, color: theme.colorScheme.primary),
+          ),
+          const SizedBox(width: 16),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  event.label,
+                  style: theme.textTheme.titleSmall?.copyWith(
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                const SizedBox(height: 4),
+                Text(
+                  dateFormat.format(event.timestamp),
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/modules/pickup/views/teacher_pickup_view.dart
+++ b/lib/modules/pickup/views/teacher_pickup_view.dart
@@ -3,17 +3,17 @@ import 'package:get/get.dart';
 import 'package:intl/intl.dart';
 
 import '../../../data/models/pickup_model.dart';
-import '../../common/widgets/module_card.dart';
 import '../../common/widgets/module_empty_state.dart';
 import '../../common/widgets/module_page_container.dart';
 import '../controllers/teacher_pickup_controller.dart';
+import 'widgets/pickup_queue_card.dart';
 
 class TeacherPickupView extends GetView<TeacherPickupController> {
   const TeacherPickupView({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final timeFormat = DateFormat.jm();
+    final timeFormat = DateFormat('MMM d • h:mm a');
     return Scaffold(
       appBar: AppBar(
         title: const Text('Pickup Queue'),
@@ -30,7 +30,7 @@ class TeacherPickupView extends GetView<TeacherPickupController> {
               Expanded(
                 child: Builder(
                   builder: (context) {
-                    final tickets = controller.tickets;
+                    final tickets = controller.tickets.toList();
                     return RefreshIndicator(
                       onRefresh: controller.refreshTickets,
                       child: tickets.isEmpty
@@ -50,7 +50,7 @@ class TeacherPickupView extends GetView<TeacherPickupController> {
                           : ListView.separated(
                               padding:
                                   const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                              physics: AlwaysScrollableScrollPhysics(
+                              physics: const AlwaysScrollableScrollPhysics(
                                 parent: BouncingScrollPhysics(),
                               ),
                               itemCount: tickets.length,
@@ -58,67 +58,11 @@ class TeacherPickupView extends GetView<TeacherPickupController> {
                                   const SizedBox(height: 16),
                               itemBuilder: (context, index) {
                                 final ticket = tickets[index];
-                                return ModuleCard(
-                                  child: Column(
-                                    crossAxisAlignment:
-                                        CrossAxisAlignment.start,
-                                    children: [
-                                      Text(
-                                        '${ticket.childName} • ${ticket.className}',
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .titleMedium
-                                            ?.copyWith(
-                                              fontWeight: FontWeight.w700,
-                                            ),
-                                      ),
-                                      const SizedBox(height: 8),
-                                      Text(
-                                        'Stage: ${_stageLabel(ticket.stage)}',
-                                        style: Theme.of(context)
-                                            .textTheme
-                                            .bodySmall
-                                            ?.copyWith(
-                                              color: Theme.of(context)
-                                                  .colorScheme
-                                                  .onSurfaceVariant,
-                                            ),
-                                      ),
-                                      if (ticket.parentConfirmedAt != null)
-                                        Text(
-                                          'Parent confirmed at ${timeFormat.format(ticket.parentConfirmedAt!)}',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodySmall,
-                                        ),
-                                      if (ticket.teacherValidatedAt != null)
-                                        Text(
-                                          'Teacher validated at ${timeFormat.format(ticket.teacherValidatedAt!)}',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodySmall,
-                                        ),
-                                      if (ticket.adminValidatedAt != null)
-                                        Text(
-                                          'Admin validated at ${timeFormat.format(ticket.adminValidatedAt!)}',
-                                          style: Theme.of(context)
-                                              .textTheme
-                                              .bodySmall,
-                                        ),
-                                      if (ticket.stage ==
-                                          PickupStage.awaitingTeacher) ...[
-                                        const SizedBox(height: 16),
-                                        Align(
-                                          alignment: Alignment.centerRight,
-                                          child: ElevatedButton(
-                                            onPressed: () => controller
-                                                .validatePickup(ticket),
-                                            child: const Text('Validate'),
-                                          ),
-                                        ),
-                                      ],
-                                    ],
-                                  ),
+                                return PickupQueueCard(
+                                  ticket: ticket,
+                                  timeFormat: timeFormat,
+                                  onValidate: () =>
+                                      controller.validatePickup(ticket),
                                 );
                               },
                             ),
@@ -245,18 +189,5 @@ class _ActiveFilterChip extends StatelessWidget {
         fontWeight: FontWeight.w600,
       ),
     );
-  }
-}
-
-String _stageLabel(PickupStage stage) {
-  switch (stage) {
-    case PickupStage.awaitingParent:
-      return 'Waiting for parent confirmation';
-    case PickupStage.awaitingTeacher:
-      return 'Waiting for teacher validation';
-    case PickupStage.awaitingAdmin:
-      return 'Waiting for admin release';
-    case PickupStage.completed:
-      return 'Completed';
   }
 }

--- a/lib/modules/pickup/views/widgets/pickup_queue_card.dart
+++ b/lib/modules/pickup/views/widgets/pickup_queue_card.dart
@@ -1,0 +1,209 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+import '../../../../data/models/pickup_model.dart';
+import '../../../common/widgets/module_card.dart';
+
+class PickupQueueCard extends StatelessWidget {
+  const PickupQueueCard({
+    super.key,
+    required this.ticket,
+    required this.timeFormat,
+    this.onValidate,
+    this.actionLabel,
+    this.actionIcon,
+    this.trailing,
+  });
+
+  final PickupTicketModel ticket;
+  final DateFormat timeFormat;
+  final VoidCallback? onValidate;
+  final String? actionLabel;
+  final IconData? actionIcon;
+  final Widget? trailing;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final metadata = _buildMetadata();
+    final stageLabel = _stageLabel(ticket.stage);
+    final stageColor = _stageColor(theme, ticket.stage);
+
+    return ModuleCard(
+      padding: const EdgeInsets.fromLTRB(20, 18, 20, 20),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      ticket.childName,
+                      style: theme.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    const SizedBox(height: 6),
+                    Text(
+                      '${ticket.className} • ${ticket.parentName}',
+                      style: theme.textTheme.bodySmall?.copyWith(
+                        color: theme.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              _StageChip(label: stageLabel, color: stageColor),
+            ],
+          ),
+          const SizedBox(height: 16),
+          if (metadata.isNotEmpty)
+            Wrap(
+              spacing: 12,
+              runSpacing: 12,
+              children: metadata,
+            ),
+          if (metadata.isNotEmpty) const SizedBox(height: 16),
+          Row(
+            children: [
+              if (onValidate != null)
+                FilledButton.icon(
+                  onPressed: onValidate,
+                  icon: Icon(actionIcon ?? Icons.verified_outlined, size: 18),
+                  label: Text(actionLabel ?? 'Validate pickup'),
+                ),
+              if (trailing != null) ...[
+                if (onValidate != null) const SizedBox(width: 12),
+                trailing!,
+              ],
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<Widget> _buildMetadata() {
+    final items = <Widget>[];
+    final parentConfirmed = ticket.parentConfirmedAt;
+    final teacherValidated = ticket.teacherValidatedAt;
+    final adminValidated = ticket.adminValidatedAt;
+
+    items.add(
+      _InfoChip(
+        icon: Icons.schedule,
+        label: 'Created ${timeFormat.format(ticket.createdAt)}',
+      ),
+    );
+
+    if (parentConfirmed != null) {
+      items.add(
+        _InfoChip(
+          icon: Icons.directions_walk,
+          label: 'Parent arrived ${timeFormat.format(parentConfirmed)}',
+        ),
+      );
+    }
+
+    if (teacherValidated != null) {
+      items.add(
+        _InfoChip(
+          icon: Icons.verified_outlined,
+          label: 'Teacher released ${timeFormat.format(teacherValidated)}',
+        ),
+      );
+    }
+
+    if (adminValidated != null) {
+      items.add(
+        _InfoChip(
+          icon: Icons.admin_panel_settings_outlined,
+          label: 'Admin released ${timeFormat.format(adminValidated)}',
+        ),
+      );
+    }
+
+    return items;
+  }
+}
+
+class _StageChip extends StatelessWidget {
+  const _StageChip({required this.label, required this.color});
+
+  final String label;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(20),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+        child: Text(
+          label,
+          style: theme.textTheme.labelMedium?.copyWith(
+            color: color,
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _InfoChip extends StatelessWidget {
+  const _InfoChip({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Chip(
+      avatar: Icon(icon, size: 18, color: theme.colorScheme.primary),
+      label: Text(label),
+      backgroundColor: theme.colorScheme.primary.withOpacity(0.08),
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+      labelStyle: theme.textTheme.bodySmall?.copyWith(
+        color: theme.colorScheme.primary,
+        fontWeight: FontWeight.w600,
+      ),
+    );
+  }
+}
+
+String _stageLabel(PickupStage stage) {
+  switch (stage) {
+    case PickupStage.awaitingParent:
+      return 'Waiting for parent';
+    case PickupStage.awaitingTeacher:
+      return 'Waiting for release';
+    case PickupStage.awaitingAdmin:
+      return 'Waiting for admin';
+    case PickupStage.completed:
+      return 'Completed';
+  }
+}
+
+Color _stageColor(ThemeData theme, PickupStage stage) {
+  switch (stage) {
+    case PickupStage.awaitingParent:
+      return theme.colorScheme.secondary;
+    case PickupStage.awaitingTeacher:
+      return theme.colorScheme.primary;
+    case PickupStage.awaitingAdmin:
+      return theme.colorScheme.tertiary;
+    case PickupStage.completed:
+      return theme.colorScheme.onSurfaceVariant;
+  }
+}


### PR DESCRIPTION
## Summary
- ensure pickup tickets remain live by filtering teacher/admin queues to awaiting release and updating state after validation
- refresh UI with shared queue card styling, renamed admin queue, and improved archived pickup list with detail navigation
- add comprehensive pickup detail view including validator metadata and keep parent notifications active after teacher validation

## Testing
- Unable to run Flutter tooling in container (flutter command not available)


------
https://chatgpt.com/codex/tasks/task_e_68d58370efbc8331950b92896e9dc340