### PR TITLE
Fix pickup initials helper return type

### DIFF
--- a/lib/modules/pickup/views/pickup_ticket_detail_view.dart
+++ b/lib/modules/pickup/views/pickup_ticket_detail_view.dart
@@ -536,14 +536,14 @@ class PickupTicketDetailView extends StatelessWidget {
     return 'Pickup in progress';
   }
 
-  Object _initialsFor(String input) {
+  String _initialsFor(String input) {
     final normalized = input.trim();
     if (normalized.isEmpty) {
       return 'ST';
     }
-    final parts = normalized.split(' ');
+    final parts = normalized.split(RegExp(r'\s+')).where((part) => part.isNotEmpty).toList();
     if (parts.length == 1) {
-      return normalized.characters.take(2).toUpperCase();
+      return parts.first.characters.take(2).toString().toUpperCase();
     }
     final first = parts.first.characters.first;
     final last = parts.last.characters.first;


### PR DESCRIPTION
## Summary
- ensure the pickup ticket initials helper returns a string instead of a generic object
- handle multi-space names by splitting on whitespace and limiting initials extraction accordingly

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d58dd0c27883319e7a2946cf8a40d0