### PR TITLE
Adjust pickup flows and archived detail display

### DIFF
--- a/lib/modules/attendance/controllers/teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/teacher_attendance_controller.dart
@@ -13,6 +13,7 @@ import '../../../core/services/pdf_downloader/pdf_downloader.dart';
 import '../../../data/models/attendance_record_model.dart';
 import '../../../data/models/child_model.dart';
 import '../../../data/models/parent_model.dart';
+import '../../../data/models/pickup_model.dart';
 import '../../../data/models/school_class_model.dart';
 import '../../../data/models/teacher_model.dart';
 
@@ -511,6 +512,10 @@ class TeacherAttendanceController extends GetxController {
       final existingTicket = await ticketRef.get();
 
       if (existingTicket.exists) {
+        final pickupTicket = PickupTicketModel.fromDoc(existingTicket);
+        if (pickupTicket.isArchived || pickupTicket.teacherValidatedAt != null) {
+          continue;
+        }
         await ticketRef.set(
           <String, dynamic>{
             'childId': child.id,

--- a/lib/modules/pickup/controllers/admin_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/admin_pickup_controller.dart
@@ -40,13 +40,13 @@ class AdminPickupController extends GetxController {
   final RxList<SchoolClassModel> classes = <SchoolClassModel>[].obs;
 
   final RxnString classFilter = RxnString();
-  final Rx<PickupStage?> stageFilter = Rx<PickupStage?>(PickupStage.awaitingTeacher);
+  final Rx<PickupStage?> stageFilter = Rx<PickupStage?>(PickupStage.awaitingAdmin);
   final Rxn<AdminModel> admin = Rxn<AdminModel>();
   final RxBool isLoading = false.obs;
 
   void clearFilters() {
     classFilter.value = null;
-    stageFilter.value = PickupStage.awaitingTeacher;
+    stageFilter.value = PickupStage.awaitingAdmin;
     _applyFilters();
   }
 

--- a/lib/modules/pickup/controllers/teacher_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/teacher_pickup_controller.dart
@@ -128,7 +128,6 @@ class TeacherPickupController extends GetxController {
       teacherValidatorId: currentTeacher.id,
       teacherValidatorName: currentTeacher.name,
       teacherValidatedAt: now,
-      archivedAt: now,
     );
     final index = _allTickets.indexWhere((item) => item.id == ticket.id);
     if (index != -1) {

--- a/lib/modules/pickup/views/admin_pickup_view.dart
+++ b/lib/modules/pickup/views/admin_pickup_view.dart
@@ -54,14 +54,13 @@ class AdminPickupView extends GetView<AdminPickupController> {
                           separatorBuilder: (_, __) => const SizedBox(height: 16),
                           itemBuilder: (context, index) {
                             final ticket = items[index];
-                            final showAction = !ticket.isArchived;
+                            final showAction =
+                                ticket.stage == PickupStage.awaitingAdmin && !ticket.isArchived;
                             return PickupQueueCard(
                               ticket: ticket,
                               timeFormat: timeFormat,
                               onValidate:
                                   showAction ? () => controller.finalizeTicket(ticket) : null,
-                              actionLabel: 'Validate release',
-                              actionIcon: Icons.task_alt_outlined,
                             );
                           },
                         ),
@@ -90,7 +89,7 @@ class _AdminPickupFilters extends StatelessWidget {
           Obx(() {
             final stageValue = controller.stageFilter.value;
             final hasStageFilter =
-                stageValue != null && stageValue != PickupStage.awaitingTeacher;
+                stageValue != null && stageValue != PickupStage.awaitingAdmin;
             final hasFilters =
                 (controller.classFilter.value ?? '').isNotEmpty || hasStageFilter;
             return Row(
@@ -123,7 +122,7 @@ class _AdminPickupFilters extends StatelessWidget {
                 ),
               );
             }
-            if (stage != null && stage != PickupStage.awaitingTeacher) {
+            if (stage != null && stage != PickupStage.awaitingAdmin) {
               chips.add(
                 _ActiveFilterChip(
                   label: 'Status: ${_stageFilterLabel(stage)}',

--- a/lib/modules/pickup/views/pickup_ticket_detail_view.dart
+++ b/lib/modules/pickup/views/pickup_ticket_detail_view.dart
@@ -521,11 +521,25 @@ class PickupTicketDetailView extends StatelessWidget {
   }
 
   String _stageHeadline() {
-    if (ticket.releasedByTeacher) {
-      return 'Released by ${ticket.teacherValidatorName.isEmpty ? 'teacher' : ticket.teacherValidatorName}';
+    if (ticket.isArchived) {
+      if (ticket.releasedByAdmin) {
+        final adminName =
+            ticket.adminValidatorName.isEmpty ? 'admin' : ticket.adminValidatorName;
+        return 'Released by $adminName';
+      }
+      if (ticket.releasedByTeacher) {
+        final teacherName = ticket.teacherValidatorName.isEmpty
+            ? 'teacher'
+            : ticket.teacherValidatorName;
+        return 'Released by $teacherName';
+      }
+      return 'Pickup archived';
     }
     if (ticket.releasedByAdmin) {
       return 'Released by ${ticket.adminValidatorName.isEmpty ? 'admin' : ticket.adminValidatorName}';
+    }
+    if (ticket.releasedByTeacher) {
+      return 'Released by ${ticket.teacherValidatorName.isEmpty ? 'teacher' : ticket.teacherValidatorName}';
     }
     if (ticket.isAwaitingTeacher) {
       return 'Waiting for release';


### PR DESCRIPTION
## Summary
- prevent archived pickup tickets from being recreated during attendance syncing
- leave tickets awaiting admin validation when teachers approve pickups and show accurate archived detail headlines
- update the admin pickup queue defaults and actions to mirror the teacher experience

## Testing
- ❌ `flutter test` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d591a1f36c8331b895d346a426b930