### PR TITLE
Align attendance download button and chip styles

### DIFF
--- a/lib/modules/attendance/views/widgets/child_attendance_detail_content.dart
+++ b/lib/modules/attendance/views/widgets/child_attendance_detail_content.dart
@@ -312,17 +312,23 @@ class ChildAttendanceDetailContent extends StatelessWidget {
   }
 
   Widget _buildDownloadButton(BuildContext context) {
-    return Align(
-      alignment: Alignment.center,
-      child: FilledButton.icon(
+    return SizedBox(
+      width: double.infinity,
+      child: ElevatedButton.icon(
         onPressed: isExporting ? null : onDownload,
         icon: isExporting
             ? const SizedBox(
                 width: 18,
                 height: 18,
-                child: CircularProgressIndicator(strokeWidth: 2),
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                ),
               )
-            : const Icon(Icons.picture_as_pdf_outlined),
+            : const Icon(
+                Icons.picture_as_pdf_outlined,
+                color: Colors.white,
+              ),
         label: Text(isExporting ? 'Preparing...' : downloadLabel),
       ),
     );

--- a/lib/modules/behavior/widgets/behavior_type_chip.dart
+++ b/lib/modules/behavior/widgets/behavior_type_chip.dart
@@ -39,7 +39,7 @@ class BehaviorTypeChip extends StatelessWidget {
       ),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(18),
-        side: BorderSide.none,
+        side: const BorderSide(color: Colors.transparent),
       ),
     );
   }

--- a/lib/modules/homework/views/parent_homework_list_view.dart
+++ b/lib/modules/homework/views/parent_homework_list_view.dart
@@ -321,6 +321,10 @@ class _ParentHomeworkCard extends StatelessWidget {
                             : theme.colorScheme.secondary,
                         fontWeight: FontWeight.w600,
                       ),
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                        side: const BorderSide(color: Colors.transparent),
+                      ),
                     ),
                   )
                   .toList(),


### PR DESCRIPTION
## Summary
- Match the attendance detail download action with the full-width elevated style used on course details.
- Remove chip borders from behavior type notes so positive and negative badges render without dark outlines.
- Drop borders from homework child status chips for a softer list presentation.

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d59edd9a98833193bf230d6c1ac673