### PR TITLE
Enable pull-to-refresh for teacher modules

### DIFF
--- a/lib/modules/attendance/controllers/teacher_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/teacher_attendance_controller.dart
@@ -58,6 +58,57 @@ class TeacherAttendanceController extends GetxController {
     _initialize();
   }
 
+  Future<void> refreshData() async {
+    final teacherId = teacher.value?.id ?? _auth.currentUser?.uid;
+    if (teacherId == null) {
+      Get.snackbar(
+        'Authentication required',
+        'Unable to determine the authenticated teacher.',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
+    }
+
+    try {
+      final teacherDoc =
+          await _db.firestore.collection('teachers').doc(teacherId).get();
+      if (teacherDoc.exists) {
+        teacher.value = TeacherModel.fromDoc(teacherDoc);
+      }
+
+      final classesSnap = await _db.firestore.collection('classes').get();
+      final teacherClasses = classesSnap.docs
+          .map(SchoolClassModel.fromDoc)
+          .where((item) => item.teacherSubjects.values.contains(teacherId))
+          .toList();
+      setClasses(teacherClasses);
+      _syncChildrenListeners(teacherClasses);
+
+      for (final schoolClass in teacherClasses) {
+        final childrenSnap = await _db.firestore
+            .collection('children')
+            .where('classId', isEqualTo: schoolClass.id)
+            .get();
+        registerChildren(
+          schoolClass.id,
+          childrenSnap.docs.map(ChildModel.fromDoc).toList(),
+        );
+      }
+
+      final sessionsSnap = await _db.firestore
+          .collection('attendanceSessions')
+          .where('teacherId', isEqualTo: teacherId)
+          .get();
+      setSessions(sessionsSnap.docs.map(AttendanceSessionModel.fromDoc).toList());
+    } catch (error) {
+      Get.snackbar(
+        'Refresh failed',
+        'Unable to refresh attendance data: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+
   @override
   void onClose() {
     for (final subscription in _childrenSubscriptions.values) {

--- a/lib/modules/courses/views/teacher_courses_view.dart
+++ b/lib/modules/courses/views/teacher_courses_view.dart
@@ -39,58 +39,63 @@ class TeacherCoursesView extends StatelessWidget {
             children: [
               _buildFilters(context),
               Expanded(
-                child: controller.courses.isEmpty
-                    ? _buildEmptyState(context)
-                    : ListView.separated(
-                        padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
-                        physics: const BouncingScrollPhysics(),
-                        itemCount: controller.courses.length,
-                        separatorBuilder: (_, __) => const SizedBox(height: 16),
-                        itemBuilder: (context, index) {
-                          final course = controller.courses[index];
-                          return Dismissible(
-                            key: ValueKey(course.id),
-                            background: SwipeActionBackground(
-                              alignment: Alignment.centerLeft,
-                              color: theme.colorScheme.primary,
-                              icon: Icons.edit_outlined,
-                              label: 'Edit',
-                            ),
-                            secondaryBackground: SwipeActionBackground(
-                              alignment: Alignment.centerRight,
-                              color: theme.colorScheme.error,
-                              icon: Icons.delete_outline,
-                              label: 'Delete',
-                            ),
-                            confirmDismiss: (direction) async {
-                              if (direction == DismissDirection.startToEnd) {
-                                controller.openForm(course: course);
-                                return false;
-                              }
-                              final confirmed = await _confirmDelete(context);
-                              if (confirmed == true) {
-                                await controller.deleteCourse(course.id);
-                              }
-                              return confirmed ?? false;
-                            },
-                            child: _CourseListTile(
-                              course: course,
-                              onTap: () {
-                                Get.to(
-                                  () => CourseDetailView(
-                                    course: course,
-                                    onEdit: () async {
-                                      Get.back();
-                                      await Future<void>.delayed(Duration.zero);
-                                      controller.openForm(course: course);
-                                    },
-                                  ),
-                                );
+                child: RefreshIndicator(
+                  onRefresh: controller.refreshData,
+                  child: controller.courses.isEmpty
+                      ? _buildEmptyState(context)
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 100),
+                          physics: const BouncingScrollPhysics(
+                            parent: AlwaysScrollableScrollPhysics(),
+                          ),
+                          itemCount: controller.courses.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final course = controller.courses[index];
+                            return Dismissible(
+                              key: ValueKey(course.id),
+                              background: SwipeActionBackground(
+                                alignment: Alignment.centerLeft,
+                                color: theme.colorScheme.primary,
+                                icon: Icons.edit_outlined,
+                                label: 'Edit',
+                              ),
+                              secondaryBackground: SwipeActionBackground(
+                                alignment: Alignment.centerRight,
+                                color: theme.colorScheme.error,
+                                icon: Icons.delete_outline,
+                                label: 'Delete',
+                              ),
+                              confirmDismiss: (direction) async {
+                                if (direction == DismissDirection.startToEnd) {
+                                  controller.openForm(course: course);
+                                  return false;
+                                }
+                                final confirmed = await _confirmDelete(context);
+                                if (confirmed == true) {
+                                  await controller.deleteCourse(course.id);
+                                }
+                                return confirmed ?? false;
                               },
-                            ),
-                          );
-                        },
-                      ),
+                              child: _CourseListTile(
+                                course: course,
+                                onTap: () {
+                                  Get.to(
+                                    () => CourseDetailView(
+                                      course: course,
+                                      onEdit: () async {
+                                        Get.back();
+                                        await Future<void>.delayed(Duration.zero);
+                                        controller.openForm(course: course);
+                                      },
+                                    ),
+                                  );
+                                },
+                              ),
+                            );
+                          },
+                        ),
+                ),
               ),
             ],
           ),
@@ -110,43 +115,42 @@ class TeacherCoursesView extends StatelessWidget {
 
   Widget _buildEmptyState(BuildContext context) {
     final theme = Theme.of(context);
-    return Center(
-      child: Padding(
-        padding: const EdgeInsets.all(32),
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            Container(
-              width: 88,
-              height: 88,
-              decoration: BoxDecoration(
-                color: theme.colorScheme.primary.withOpacity(0.12),
-                shape: BoxShape.circle,
-              ),
-              child: Icon(
-                Icons.menu_book_outlined,
-                color: theme.colorScheme.primary,
-                size: 40,
-              ),
-            ),
-            const SizedBox(height: 24),
-            Text(
-              'No courses yet',
-              style: theme.textTheme.titleMedium?.copyWith(
-                fontWeight: FontWeight.w600,
-              ),
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Tap the button below to publish your first course.',
-              textAlign: TextAlign.center,
-              style: theme.textTheme.bodyMedium?.copyWith(
-                color: theme.colorScheme.onSurfaceVariant,
-              ),
-            ),
-          ],
+    return ListView(
+      physics: const AlwaysScrollableScrollPhysics(),
+      padding: const EdgeInsets.all(32),
+      children: [
+        const SizedBox(height: 120),
+        Container(
+          width: 88,
+          height: 88,
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primary.withOpacity(0.12),
+            shape: BoxShape.circle,
+          ),
+          child: Icon(
+            Icons.menu_book_outlined,
+            color: theme.colorScheme.primary,
+            size: 40,
+          ),
         ),
-      ),
+        const SizedBox(height: 24),
+        Text(
+          'No courses yet',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w600,
+          ),
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Tap the button below to publish your first course.',
+          textAlign: TextAlign.center,
+          style: theme.textTheme.bodyMedium?.copyWith(
+            color: theme.colorScheme.onSurfaceVariant,
+          ),
+        ),
+        const SizedBox(height: 160),
+      ],
     );
   }
 

--- a/lib/modules/homework/views/teacher_homework_list_view.dart
+++ b/lib/modules/homework/views/teacher_homework_list_view.dart
@@ -40,82 +40,90 @@ class TeacherHomeworkListView extends GetView<TeacherHomeworkController> {
                   return const Center(child: CircularProgressIndicator());
                 }
                 final items = controller.homeworks;
-                if (items.isEmpty) {
-                  return ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                    children: const [
-                      ModuleEmptyState(
-                        icon: Icons.menu_book_outlined,
-                        title: 'No homework assignments found',
-                        message:
-                            'Create your first assignment to help students stay on track.',
-                      ),
-                    ],
-                  );
-                }
-                return ListView.separated(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 120),
-                  physics: const BouncingScrollPhysics(
-                    parent: AlwaysScrollableScrollPhysics(),
-                  ),
-                  itemCount: items.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 16),
-                  itemBuilder: (context, index) {
-                    final homework = items[index];
-                    final totalChildren =
-                        controller.childCountForClass(homework.classId);
-                    return Dismissible(
-                      key: ValueKey(homework.id),
-                      background: SwipeActionBackground(
-                        alignment: Alignment.centerLeft,
-                        color: Theme.of(context).colorScheme.primary,
-                        icon: Icons.edit_outlined,
-                        label: 'Edit',
-                      ),
-                      secondaryBackground: SwipeActionBackground(
-                        alignment: Alignment.centerRight,
-                        color: Theme.of(context).colorScheme.error,
-                        icon: Icons.delete_outline,
-                        label: 'Delete',
-                      ),
-                      confirmDismiss: (direction) async {
-                        if (direction == DismissDirection.startToEnd) {
-                          controller.startEdit(homework);
-                          await Get.to(
-                            () => const TeacherHomeworkFormView(),
-                          );
-                          return false;
-                        }
-                        return _confirmDelete(context);
-                      },
-                      onDismissed: (_) {
-                        controller.removeHomework(homework);
-                      },
-                      child: _TeacherHomeworkCard(
-                        homework: homework,
-                        dateFormat: dateFormat,
-                        totalChildren: totalChildren,
-                        onTap: () {
-                          Get.to(
-                            () => HomeworkDetailView(
-                              homework: homework,
-                              initialChildCount: totalChildren,
-                              showTeacherInsights: true,
-                              onEdit: () async {
-                                Get.back();
-                                await Future<void>.delayed(Duration.zero);
-                                controller.startEdit(homework);
-                                await Get.to(
-                                  () => const TeacherHomeworkFormView(),
-                                );
-                              },
+                return RefreshIndicator(
+                  onRefresh: controller.refreshData,
+                  child: items.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding:
+                              const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                          children: const [
+                            ModuleEmptyState(
+                              icon: Icons.menu_book_outlined,
+                              title: 'No homework assignments found',
+                              message:
+                                  'Create your first assignment to help students stay on track.',
                             ),
-                          );
-                        },
-                      ),
-                    );
-                  },
+                          ],
+                        )
+                      : ListView.separated(
+                          padding:
+                              const EdgeInsets.fromLTRB(16, 16, 16, 120),
+                          physics: const BouncingScrollPhysics(
+                            parent: AlwaysScrollableScrollPhysics(),
+                          ),
+                          itemCount: items.length,
+                          separatorBuilder: (_, __) =>
+                              const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final homework = items[index];
+                            final totalChildren =
+                                controller.childCountForClass(homework.classId);
+                            return Dismissible(
+                              key: ValueKey(homework.id),
+                              background: SwipeActionBackground(
+                                alignment: Alignment.centerLeft,
+                                color:
+                                    Theme.of(context).colorScheme.primary,
+                                icon: Icons.edit_outlined,
+                                label: 'Edit',
+                              ),
+                              secondaryBackground: SwipeActionBackground(
+                                alignment: Alignment.centerRight,
+                                color: Theme.of(context).colorScheme.error,
+                                icon: Icons.delete_outline,
+                                label: 'Delete',
+                              ),
+                              confirmDismiss: (direction) async {
+                                if (direction == DismissDirection.startToEnd) {
+                                  controller.startEdit(homework);
+                                  await Get.to(
+                                    () => const TeacherHomeworkFormView(),
+                                  );
+                                  return false;
+                                }
+                                return _confirmDelete(context);
+                              },
+                              onDismissed: (_) {
+                                controller.removeHomework(homework);
+                              },
+                              child: _TeacherHomeworkCard(
+                                homework: homework,
+                                dateFormat: dateFormat,
+                                totalChildren: totalChildren,
+                                onTap: () {
+                                  Get.to(
+                                    () => HomeworkDetailView(
+                                      homework: homework,
+                                      initialChildCount: totalChildren,
+                                      showTeacherInsights: true,
+                                      onEdit: () async {
+                                        Get.back();
+                                        await Future<void>.delayed(
+                                            Duration.zero);
+                                        controller.startEdit(homework);
+                                        await Get.to(
+                                          () =>
+                                              const TeacherHomeworkFormView(),
+                                        );
+                                      },
+                                    ),
+                                  );
+                                },
+                              ),
+                            );
+                          },
+                        ),
                 );
               }),
             ),


### PR DESCRIPTION
## Summary
- add explicit refresh helpers for teacher course, homework, and attendance controllers
- enable pull-to-refresh on the respective list views with updated empty states
- restyle the attendance detail view with an in-page PDF export button and scrollable layout

## Testing
- `flutter test` *(fails: Flutter CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a7cd7b6c8331869a982e967db658