### PR TITLE
Adjust teacher attendance detail header styling

### DIFF
--- a/lib/modules/attendance/views/teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/teacher_attendance_view.dart
@@ -372,8 +372,20 @@ class _TeacherClassDetail extends StatelessWidget {
                   .where((entry) => entry.status == AttendanceStatus.present)
                   .length;
               final total = entries.length;
+              final primary = theme.colorScheme.primary;
               return AttendanceDateCard(
                 padding: const EdgeInsets.fromLTRB(24, 24, 24, 24),
+                backgroundColor: primary,
+                borderColor: Colors.transparent,
+                shadowColor: primary.withOpacity(0.35),
+                overlayGradient: LinearGradient(
+                  colors: [
+                    primary.withOpacity(0.92),
+                    primary,
+                  ],
+                  begin: Alignment.topLeft,
+                  end: Alignment.bottomRight,
+                ),
                 child: Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [


### PR DESCRIPTION
## Summary
- update the teacher attendance detail header card to use the blue hero styling seen in announcement details
- customize the card background, gradient, and shadow so text remains legible on the new blue treatment

## Testing
- flutter analyze *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c8a3271083319b67fd97b3ca74fd