### PR TITLE
Fix missing parentheses in teacher attendance overview

### DIFF
--- a/lib/modules/attendance/views/teacher_attendance_view.dart
+++ b/lib/modules/attendance/views/teacher_attendance_view.dart
@@ -172,71 +172,73 @@ class _TeacherClassListState extends State<_TeacherClassList> {
                     child: Column(
                       crossAxisAlignment: CrossAxisAlignment.start,
                       children: [
-                    Row(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Expanded(
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              Text(
-                                'Attendance overview',
-                                style: theme.textTheme.titleMedium?.copyWith(
-                                  fontWeight: FontWeight.w700,
-                                ),
-                              ),
-                              const SizedBox(height: 4),
-                              Text(
-                                dateLabel,
-                                style: theme.textTheme.bodySmall?.copyWith(
-                                  color: theme.colorScheme.onSurfaceVariant,
-                                ),
-                              ),
-                            ],
-                          ),
-                        ),
-                        Wrap(
-                          alignment: WrapAlignment.end,
-                          spacing: 8,
-                          runSpacing: 8,
+                        Row(
+                          crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            if (!isToday)
-                              OutlinedButton.icon(
-                                onPressed: () =>
-                                    controller.setDate(DateTime.now()),
-                                icon: const Icon(Icons.refresh, size: 18),
-                                label: const Text('Clear date'),
+                            Expanded(
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Text(
+                                    'Attendance overview',
+                                    style: theme.textTheme.titleMedium?.copyWith(
+                                      fontWeight: FontWeight.w700,
+                                    ),
+                                  ),
+                                  const SizedBox(height: 4),
+                                  Text(
+                                    dateLabel,
+                                    style: theme.textTheme.bodySmall?.copyWith(
+                                      color: theme.colorScheme.onSurfaceVariant,
+                                    ),
+                                  ),
+                                ],
                               ),
-                            TextButton.icon(
-                              onPressed: () async {
-                                final picked = await showDatePicker(
-                                  context: context,
-                                  initialDate: selectedDate,
-                                  firstDate: DateTime(selectedDate.year - 1),
-                                  lastDate: DateTime(selectedDate.year + 1),
-                                );
-                                if (picked != null) {
-                                  controller.setDate(picked);
-                                }
-                              },
-                              icon: const Icon(Icons.calendar_today, size: 18),
-                              label:
-                                  Text(isToday ? 'Select date' : 'Change date'),
+                            ),
+                            Wrap(
+                              alignment: WrapAlignment.end,
+                              spacing: 8,
+                              runSpacing: 8,
+                              children: [
+                                if (!isToday)
+                                  OutlinedButton.icon(
+                                    onPressed: () =>
+                                        controller.setDate(DateTime.now()),
+                                    icon: const Icon(Icons.refresh, size: 18),
+                                    label: const Text('Clear date'),
+                                  ),
+                                TextButton.icon(
+                                  onPressed: () async {
+                                    final picked = await showDatePicker(
+                                      context: context,
+                                      initialDate: selectedDate,
+                                      firstDate: DateTime(selectedDate.year - 1),
+                                      lastDate: DateTime(selectedDate.year + 1),
+                                    );
+                                    if (picked != null) {
+                                      controller.setDate(picked);
+                                    }
+                                  },
+                                  icon:
+                                      const Icon(Icons.calendar_today, size: 18),
+                                  label: Text(
+                                      isToday ? 'Select date' : 'Change date'),
+                                ),
+                              ],
                             ),
                           ],
                         ),
+                        const SizedBox(height: 12),
+                        Text(
+                          'Choose a date to review and mark attendance for your classes.',
+                          style: theme.textTheme.bodyMedium?.copyWith(
+                            color: theme.colorScheme.onSurfaceVariant,
+                          ),
+                        ),
                       ],
                     ),
-                    const SizedBox(height: 12),
-                    Text(
-                      'Choose a date to review and mark attendance for your classes.',
-                      style: theme.textTheme.bodyMedium?.copyWith(
-                        color: theme.colorScheme.onSurfaceVariant,
-                      ),
-                    ),
-                  ],
-                ),
-              );
+                  ),
+                );
             }),
           ),
         ),


### PR DESCRIPTION
## Summary
- add the missing closing parenthesis when returning the attendance overview `KeyedSubtree`
- tidy the nested `Row`/`Wrap` layout to match the expected hierarchy after adding the closing token

## Testing
- `flutter analyze` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d5cb59952c8331892bd7b23bba5e4f