### PR TITLE
Add pull-to-refresh and refresh admin summaries

### DIFF
--- a/lib/modules/attendance/controllers/admin_attendance_controller.dart
+++ b/lib/modules/attendance/controllers/admin_attendance_controller.dart
@@ -69,6 +69,46 @@ class AdminAttendanceController extends GetxController {
     _applySessionFilters();
   }
 
+  Future<void> refreshData() async {
+    try {
+      final results = await Future.wait([
+        _db.firestore.collection('classes').get(),
+        _db.firestore.collection('teachers').get(),
+        _db.firestore.collection('subjects').get(),
+        _db.firestore.collection('children').get(),
+        _db.firestore.collection('attendanceSessions').get(),
+      ]);
+
+      final classSnapshot = results[0];
+      final teacherSnapshot = results[1];
+      final subjectSnapshot = results[2];
+      final childSnapshot = results[3];
+      final sessionSnapshot = results[4];
+
+      setClasses(
+        classSnapshot.docs.map(SchoolClassModel.fromDoc).toList(),
+      );
+      setTeachers(
+        teacherSnapshot.docs.map(TeacherModel.fromDoc).toList(),
+      );
+      setSubjects(
+        subjectSnapshot.docs.map(SubjectModel.fromDoc).toList(),
+      );
+      setChildren(
+        childSnapshot.docs.map(ChildModel.fromDoc).toList(),
+      );
+      setClassSessions(
+        sessionSnapshot.docs.map(AttendanceSessionModel.fromDoc).toList(),
+      );
+    } catch (error) {
+      Get.snackbar(
+        'Refresh failed',
+        'Unable to refresh attendance data: $error',
+        snackPosition: SnackPosition.BOTTOM,
+      );
+    }
+  }
+
   String className(String classId) {
     return classes
             .firstWhereOrNull((item) => item.id == classId)

--- a/lib/modules/attendance/views/admin_attendance_view.dart
+++ b/lib/modules/attendance/views/admin_attendance_view.dart
@@ -32,144 +32,149 @@ class AdminAttendanceView extends GetView<AdminAttendanceController> {
                   return const Center(child: CircularProgressIndicator());
                 }
                 final summaries = controller.childSummaries;
-                if (summaries.isEmpty) {
-                  return ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                    children: const [
-                      ModuleEmptyState(
-                        icon: Icons.school_outlined,
-                        title: 'No attendance data found',
-                        message:
-                            'Adjust the filters above to review attendance submissions for students.',
-                      ),
-                    ],
-                  );
-                }
                 final shortDateFormat = DateFormat.yMMMd();
-                return ListView.separated(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                  physics: const BouncingScrollPhysics(),
-                  itemCount: summaries.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 16),
-                  itemBuilder: (context, index) {
-                    final summary = summaries[index];
-                    final latestEntry = summary.subjectEntries.isEmpty
-                        ? null
-                        : summary.subjectEntries.first;
-                    final latestDateLabel = latestEntry == null
-                        ? null
-                        : shortDateFormat.format(latestEntry.date);
-                    final presentCount = summary.presentCount;
-                    final absentCount = summary.absentCount;
-                    final pendingCount = summary.pendingCount;
-                    final totalSubjects = summary.totalSubjects;
-                    final avatarText = summary.childName.isNotEmpty
-                        ? summary.childName[0].toUpperCase()
-                        : '?';
-                    final theme = Theme.of(context);
-                    return ModuleCard(
-                      onTap: () => Navigator.of(context).push(
-                        MaterialPageRoute(
-                          builder: (_) =>
-                              AdminChildAttendanceDetailView(summary: summary),
-                        ),
-                      ),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Row(
-                            crossAxisAlignment: CrossAxisAlignment.start,
-                            children: [
-                              CircleAvatar(
-                                radius: 26,
-                                backgroundColor:
-                                    theme.colorScheme.primary.withOpacity(0.12),
-                                child: Text(
-                                  avatarText,
-                                  style: theme.textTheme.titleMedium?.copyWith(
-                                    color: theme.colorScheme.primary,
-                                    fontWeight: FontWeight.bold,
+                return RefreshIndicator(
+                  onRefresh: controller.refreshData,
+                  child: summaries.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                          children: const [
+                            ModuleEmptyState(
+                              icon: Icons.school_outlined,
+                              title: 'No attendance data found',
+                              message:
+                                  'Adjust the filters above to review attendance submissions for students.',
+                            ),
+                          ],
+                        )
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                          physics: const BouncingScrollPhysics(
+                            parent: AlwaysScrollableScrollPhysics(),
+                          ),
+                          itemCount: summaries.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final summary = summaries[index];
+                            final latestEntry = summary.subjectEntries.isEmpty
+                                ? null
+                                : summary.subjectEntries.first;
+                            final latestDateLabel = latestEntry == null
+                                ? null
+                                : shortDateFormat.format(latestEntry.date);
+                            final presentCount = summary.presentCount;
+                            final absentCount = summary.absentCount;
+                            final pendingCount = summary.pendingCount;
+                            final totalSubjects = summary.totalSubjects;
+                            final avatarText = summary.childName.isNotEmpty
+                                ? summary.childName[0].toUpperCase()
+                                : '?';
+                            final theme = Theme.of(context);
+                            return ModuleCard(
+                              onTap: () => Navigator.of(context).push(
+                                MaterialPageRoute(
+                                  builder: (_) => AdminChildAttendanceDetailView(
+                                    summary: summary,
                                   ),
                                 ),
                               ),
-                              const SizedBox(width: 14),
-                              Expanded(
-                                child: Column(
-                                  crossAxisAlignment: CrossAxisAlignment.start,
-                                  children: [
-                                    Text(
-                                      summary.childName,
-                                      style: theme.textTheme.titleMedium?.copyWith(
-                                        fontWeight: FontWeight.w700,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 6),
-                                    Text(
-                                      summary.className,
-                                      style: theme.textTheme.bodySmall?.copyWith(
-                                        color:
-                                            theme.colorScheme.onSurfaceVariant,
-                                      ),
-                                    ),
-                                    const SizedBox(height: 6),
-                                    Text(
-                                      '$totalSubjects subject${totalSubjects == 1 ? '' : 's'} tracked',
-                                      style: theme.textTheme.bodySmall,
-                                    ),
-                                    if (latestDateLabel != null) ...[
-                                      const SizedBox(height: 4),
-                                      Text(
-                                        'Latest entry: $latestDateLabel',
-                                        style: theme.textTheme.bodySmall?.copyWith(
-                                          color: theme
-                                              .colorScheme.onSurfaceVariant,
+                              child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
+                                children: [
+                                  Row(
+                                    crossAxisAlignment: CrossAxisAlignment.start,
+                                    children: [
+                                      CircleAvatar(
+                                        radius: 26,
+                                        backgroundColor: theme.colorScheme.primary
+                                            .withOpacity(0.12),
+                                        child: Text(
+                                          avatarText,
+                                          style: theme.textTheme.titleMedium?.copyWith(
+                                            color: theme.colorScheme.primary,
+                                            fontWeight: FontWeight.bold,
+                                          ),
                                         ),
                                       ),
+                                      const SizedBox(width: 14),
+                                      Expanded(
+                                        child: Column(
+                                          crossAxisAlignment: CrossAxisAlignment.start,
+                                          children: [
+                                            Text(
+                                              summary.childName,
+                                              style: theme.textTheme.titleMedium?.copyWith(
+                                                fontWeight: FontWeight.w700,
+                                              ),
+                                            ),
+                                            const SizedBox(height: 6),
+                                            Text(
+                                              summary.className,
+                                              style: theme.textTheme.bodySmall?.copyWith(
+                                                color: theme
+                                                    .colorScheme.onSurfaceVariant,
+                                              ),
+                                            ),
+                                            const SizedBox(height: 6),
+                                            Text(
+                                              '$totalSubjects subject${totalSubjects == 1 ? '' : 's'} tracked',
+                                              style: theme.textTheme.bodySmall,
+                                            ),
+                                            if (latestDateLabel != null) ...[
+                                              const SizedBox(height: 4),
+                                              Text(
+                                                'Latest entry: $latestDateLabel',
+                                                style: theme.textTheme.bodySmall?.copyWith(
+                                                  color: theme.colorScheme
+                                                      .onSurfaceVariant,
+                                                ),
+                                              ),
+                                            ],
+                                          ],
+                                        ),
+                                      ),
+                                      Icon(
+                                        Icons.chevron_right,
+                                        color: theme.colorScheme.onSurfaceVariant,
+                                      ),
                                     ],
-                                  ],
-                                ),
+                                  ),
+                                  const SizedBox(height: 16),
+                                  Wrap(
+                                    spacing: 8,
+                                    runSpacing: 8,
+                                    children: [
+                                      if (presentCount > 0)
+                                        _AttendanceSummaryPill(
+                                          backgroundColor: Colors.green.shade50,
+                                          iconColor: Colors.green.shade600,
+                                          icon: Icons.check_circle,
+                                          label: '$presentCount present',
+                                        ),
+                                      if (absentCount > 0)
+                                        _AttendanceSummaryPill(
+                                          backgroundColor: theme.colorScheme.error
+                                              .withOpacity(0.12),
+                                          iconColor: theme.colorScheme.error,
+                                          icon: Icons.cancel_outlined,
+                                          label: '$absentCount absent',
+                                        ),
+                                      if (pendingCount > 0)
+                                        _AttendanceSummaryPill(
+                                          backgroundColor: theme.colorScheme.primary
+                                              .withOpacity(0.12),
+                                          iconColor: theme.colorScheme.primary,
+                                          icon: Icons.hourglass_empty,
+                                          label: '$pendingCount pending',
+                                        ),
+                                    ],
+                                  ),
+                                ],
                               ),
-                              Icon(
-                                Icons.chevron_right,
-                                color: theme.colorScheme.onSurfaceVariant,
-                              ),
-                            ],
-                          ),
-                          const SizedBox(height: 16),
-                          Wrap(
-                            spacing: 8,
-                            runSpacing: 8,
-                            children: [
-                              if (presentCount > 0)
-                                _AttendanceSummaryPill(
-                                  backgroundColor: Colors.green.shade50,
-                                  iconColor: Colors.green.shade600,
-                                  icon: Icons.check_circle,
-                                  label: '$presentCount present',
-                                ),
-                              if (absentCount > 0)
-                                _AttendanceSummaryPill(
-                                  backgroundColor:
-                                      theme.colorScheme.error.withOpacity(0.12),
-                                  iconColor: theme.colorScheme.error,
-                                  icon: Icons.cancel_outlined,
-                                  label: '$absentCount absent',
-                                ),
-                              if (pendingCount > 0)
-                                _AttendanceSummaryPill(
-                                  backgroundColor:
-                                      theme.colorScheme.primary.withOpacity(0.12),
-                                  iconColor: theme.colorScheme.primary,
-                                  icon: Icons.hourglass_empty,
-                                  label: '$pendingCount pending',
-                                ),
-                            ],
-                          ),
-                        ],
-                      ),
-                    );
-                  },
+                            );
+                          },
+                        ),
                 );
               }),
             ),

--- a/lib/modules/homework/views/admin_homework_list_view.dart
+++ b/lib/modules/homework/views/admin_homework_list_view.dart
@@ -30,45 +30,47 @@ class AdminHomeworkListView extends GetView<AdminHomeworkController> {
                   return const Center(child: CircularProgressIndicator());
                 }
                 final items = controller.homeworks;
-                if (items.isEmpty) {
-                  return ListView(
-                    physics: const AlwaysScrollableScrollPhysics(),
-                    padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                    children: const [
-                      ModuleEmptyState(
-                        icon: Icons.library_books_outlined,
-                        title: 'No homeworks match the filters',
-                        message:
-                            'Adjust the filters above to explore assignments shared across classes.',
-                      ),
-                    ],
-                  );
-                }
-                return ListView.separated(
-                  padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                  physics: const BouncingScrollPhysics(
-                    parent: AlwaysScrollableScrollPhysics(),
-                  ),
-                  itemCount: items.length,
-                  separatorBuilder: (_, __) => const SizedBox(height: 16),
-                  itemBuilder: (context, index) {
-                    final homework = items[index];
-                    final totalChildren =
-                        controller.childCountForClass(homework.classId);
-                    return _AdminHomeworkCard(
-                      homework: homework,
-                      dateFormat: dateFormat,
-                      totalChildren: totalChildren,
-                      onTap: () {
-                        Get.to(
-                          () => HomeworkDetailView(
-                            homework: homework,
-                            initialChildCount: totalChildren,
+                return RefreshIndicator(
+                  onRefresh: controller.refreshData,
+                  child: items.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                          children: const [
+                            ModuleEmptyState(
+                              icon: Icons.library_books_outlined,
+                              title: 'No homeworks match the filters',
+                              message:
+                                  'Adjust the filters above to explore assignments shared across classes.',
+                            ),
+                          ],
+                        )
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                          physics: const BouncingScrollPhysics(
+                            parent: AlwaysScrollableScrollPhysics(),
                           ),
-                        );
-                      },
-                    );
-                  },
+                          itemCount: items.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final homework = items[index];
+                            final totalChildren =
+                                controller.childCountForClass(homework.classId);
+                            return _AdminHomeworkCard(
+                              homework: homework,
+                              dateFormat: dateFormat,
+                              totalChildren: totalChildren,
+                              onTap: () {
+                                Get.to(
+                                  () => HomeworkDetailView(
+                                    homework: homework,
+                                    initialChildCount: totalChildren,
+                                  ),
+                                );
+                              },
+                            );
+                          },
+                        ),
                 );
               }),
             ),


### PR DESCRIPTION
## Summary
- add manual refresh methods for admin course, student attendance, teacher attendance, and homework controllers
- wrap corresponding list views with pull-to-refresh indicators and ensure empty states remain scrollable
- redesign the admin course stats card and reposition the teacher attendance PDF export button inside the page body

## Testing
- Not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d5d3b4dfe8833191385736827ad88f