### PR TITLE
Allow admin and teacher to validate pickups simultaneously

### DIFF
--- a/lib/data/models/pickup_model.dart
+++ b/lib/data/models/pickup_model.dart
@@ -101,7 +101,7 @@ class PickupTicketModel {
       !isArchived && parentConfirmedAt != null && teacherValidatedAt == null;
 
   bool get isAwaitingAdmin =>
-      !isArchived && teacherValidatedAt != null && adminValidatedAt == null;
+      !isArchived && parentConfirmedAt != null && adminValidatedAt == null;
 
   bool get isCompleted => isArchived;
 
@@ -118,11 +118,11 @@ class PickupTicketModel {
     if (isCompleted) {
       return PickupStage.completed;
     }
-    if (isAwaitingAdmin) {
-      return PickupStage.awaitingAdmin;
-    }
     if (isAwaitingTeacher) {
       return PickupStage.awaitingTeacher;
+    }
+    if (isAwaitingAdmin) {
+      return PickupStage.awaitingAdmin;
     }
     return PickupStage.awaitingParent;
   }

--- a/lib/modules/pickup/controllers/teacher_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/teacher_pickup_controller.dart
@@ -93,7 +93,7 @@ class TeacherPickupController extends GetxController {
       if (!teacherClassIds.contains(ticket.classId)) {
         return false;
       }
-      if (ticket.stage != PickupStage.awaitingTeacher) {
+      if (!ticket.isAwaitingTeacher) {
         return false;
       }
       if (classId != null && classId.isNotEmpty && ticket.classId != classId) {
@@ -128,6 +128,7 @@ class TeacherPickupController extends GetxController {
       teacherValidatorId: currentTeacher.id,
       teacherValidatorName: currentTeacher.name,
       teacherValidatedAt: now,
+      archivedAt: now,
     );
     final index = _allTickets.indexWhere((item) => item.id == ticket.id);
     if (index != -1) {

--- a/lib/modules/pickup/views/admin_pickup_view.dart
+++ b/lib/modules/pickup/views/admin_pickup_view.dart
@@ -42,7 +42,7 @@ class AdminPickupView extends GetView<AdminPickupController> {
                                   icon: Icons.security_outlined,
                                   title: 'No pickups ready',
                                   message:
-                                      'Once teachers release a student, the pickup will appear here for your validation.',
+                                      'Once parents confirm their arrival, the pickup will appear here for your validation.',
                                 ),
                               ],
                             )


### PR DESCRIPTION
## Summary
- allow admin pickup queue to show tickets as soon as parents confirm arrival
- let teachers finalize pickups directly by archiving tickets when they validate
- update empty state messaging to reflect the new workflow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d5e8afb1d083318235509099362aa5