### PR TITLE
Ensure pickup lists refresh after local updates

### DIFF
--- a/lib/modules/pickup/controllers/admin_archived_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/admin_archived_pickup_controller.dart
@@ -137,5 +137,6 @@ class AdminArchivedPickupController extends GetxController {
       });
 
     tickets.assignAll(filtered);
+    tickets.refresh();
   }
 }

--- a/lib/modules/pickup/controllers/admin_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/admin_pickup_controller.dart
@@ -126,6 +126,7 @@ class AdminPickupController extends GetxController {
         return bTime.compareTo(aTime);
       });
     tickets.assignAll(filtered);
+    tickets.refresh();
   }
 
   DateTime _ticketSortKey(PickupTicketModel ticket) {

--- a/lib/modules/pickup/controllers/parent_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/parent_pickup_controller.dart
@@ -81,6 +81,7 @@ class ParentPickupController extends GetxController {
     final childId = childFilter.value;
     if (_childIds.isEmpty) {
       tickets.clear();
+      tickets.refresh();
       return;
     }
     final relevantTickets = _allTickets.where((ticket) {
@@ -96,12 +97,14 @@ class ParentPickupController extends GetxController {
 
     if (childId == null || childId.isEmpty) {
       tickets.assignAll(relevantTickets);
+      tickets.refresh();
       return;
     }
 
     tickets.assignAll(
       relevantTickets.where((ticket) => ticket.childId == childId).toList(),
     );
+    tickets.refresh();
   }
 
   Future<void> confirmPickup(PickupTicketModel ticket) async {

--- a/lib/modules/pickup/controllers/teacher_pickup_controller.dart
+++ b/lib/modules/pickup/controllers/teacher_pickup_controller.dart
@@ -83,6 +83,7 @@ class TeacherPickupController extends GetxController {
     final teacherClassIds = classes.map((item) => item.id).toSet();
     if (teacherClassIds.isEmpty) {
       tickets.clear();
+      tickets.refresh();
       return;
     }
     final classId = classFilter.value;
@@ -107,6 +108,7 @@ class TeacherPickupController extends GetxController {
         return bTime.compareTo(aTime);
       });
     tickets.assignAll(filtered);
+    tickets.refresh();
   }
 
   DateTime _ticketSortTime(PickupTicketModel ticket) {


### PR DESCRIPTION
## Summary
- force pickup ticket lists to emit updates after filter changes by refreshing the reactive list state
- cover parent, teacher, admin, and archived pickup controllers so ticket actions immediately update the UI

## Testing
- `flutter analyze` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d5ec1735c08331b748035b0e5b5f97