### PR TITLE
Fix admin and teacher pickup queues real-time refresh

### DIFF
--- a/lib/modules/pickup/views/admin_pickup_view.dart
+++ b/lib/modules/pickup/views/admin_pickup_view.dart
@@ -24,46 +24,44 @@ class AdminPickupView extends GetView<AdminPickupController> {
           if (controller.isLoading.value) {
             return const Center(child: CircularProgressIndicator());
           }
+
+          final tickets = controller.tickets;
+
           return Column(
             children: [
               const _AdminPickupFilters(),
               Expanded(
-                child: Builder(
-                  builder: (context) {
-                    final items = controller.tickets.toList();
-                    return RefreshIndicator(
-                      onRefresh: controller.refreshTickets,
-                      child: items.isEmpty
-                          ? ListView(
-                              physics: const AlwaysScrollableScrollPhysics(),
-                              padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                              children: const [
-                                ModuleEmptyState(
-                                  icon: Icons.security_outlined,
-                                  title: 'No pickups ready',
-                                  message:
-                                      'Once parents confirm their arrival, the pickup will appear here for your validation.',
-                                ),
-                              ],
-                            )
-                          : ListView.separated(
-                              padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                              physics: const AlwaysScrollableScrollPhysics(
-                                parent: BouncingScrollPhysics(),
-                              ),
-                              itemCount: items.length,
-                              separatorBuilder: (_, __) => const SizedBox(height: 16),
-                              itemBuilder: (context, index) {
-                                final ticket = items[index];
-                                return PickupQueueCard(
-                                  ticket: ticket,
-                                  timeFormat: timeFormat,
-                                  onValidate: () => controller.finalizeTicket(ticket),
-                                );
-                              },
+                child: RefreshIndicator(
+                  onRefresh: controller.refreshTickets,
+                  child: tickets.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding: const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                          children: const [
+                            ModuleEmptyState(
+                              icon: Icons.security_outlined,
+                              title: 'No pickups ready',
+                              message:
+                                  'Once parents confirm their arrival, the pickup will appear here for your validation.',
                             ),
-                    );
-                  },
+                          ],
+                        )
+                      : ListView.separated(
+                          padding: const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                          physics: const AlwaysScrollableScrollPhysics(
+                            parent: BouncingScrollPhysics(),
+                          ),
+                          itemCount: tickets.length,
+                          separatorBuilder: (_, __) => const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final ticket = tickets[index];
+                            return PickupQueueCard(
+                              ticket: ticket,
+                              timeFormat: timeFormat,
+                              onValidate: () => controller.finalizeTicket(ticket),
+                            );
+                          },
+                        ),
                 ),
               ),
             ],

--- a/lib/modules/pickup/views/teacher_pickup_view.dart
+++ b/lib/modules/pickup/views/teacher_pickup_view.dart
@@ -24,50 +24,48 @@ class TeacherPickupView extends GetView<TeacherPickupController> {
           if (controller.isLoading.value) {
             return const Center(child: CircularProgressIndicator());
           }
+
+          final tickets = controller.tickets;
+
           return Column(
             children: [
               const _TeacherPickupFilters(),
               Expanded(
-                child: Builder(
-                  builder: (context) {
-                    final tickets = controller.tickets.toList();
-                    return RefreshIndicator(
-                      onRefresh: controller.refreshTickets,
-                      child: tickets.isEmpty
-                          ? ListView(
-                              physics: const AlwaysScrollableScrollPhysics(),
-                              padding:
-                                  const EdgeInsets.fromLTRB(16, 120, 16, 160),
-                              children: const [
-                                ModuleEmptyState(
-                                  icon: Icons.directions_car_outlined,
-                                  title: 'No pickup tickets',
-                                  message:
-                                      'Parents will appear here when they confirm pickups that require your validation.',
-                                ),
-                              ],
-                            )
-                          : ListView.separated(
-                              padding:
-                                  const EdgeInsets.fromLTRB(16, 16, 16, 32),
-                              physics: const AlwaysScrollableScrollPhysics(
-                                parent: BouncingScrollPhysics(),
-                              ),
-                              itemCount: tickets.length,
-                              separatorBuilder: (_, __) =>
-                                  const SizedBox(height: 16),
-                              itemBuilder: (context, index) {
-                                final ticket = tickets[index];
-                                return PickupQueueCard(
-                                  ticket: ticket,
-                                  timeFormat: timeFormat,
-                                  onValidate: () =>
-                                      controller.validatePickup(ticket),
-                                );
-                              },
+                child: RefreshIndicator(
+                  onRefresh: controller.refreshTickets,
+                  child: tickets.isEmpty
+                      ? ListView(
+                          physics: const AlwaysScrollableScrollPhysics(),
+                          padding:
+                              const EdgeInsets.fromLTRB(16, 120, 16, 160),
+                          children: const [
+                            ModuleEmptyState(
+                              icon: Icons.directions_car_outlined,
+                              title: 'No pickup tickets',
+                              message:
+                                  'Parents will appear here when they confirm pickups that require your validation.',
                             ),
-                    );
-                  },
+                          ],
+                        )
+                      : ListView.separated(
+                          padding:
+                              const EdgeInsets.fromLTRB(16, 16, 16, 32),
+                          physics: const AlwaysScrollableScrollPhysics(
+                            parent: BouncingScrollPhysics(),
+                          ),
+                          itemCount: tickets.length,
+                          separatorBuilder: (_, __) =>
+                              const SizedBox(height: 16),
+                          itemBuilder: (context, index) {
+                            final ticket = tickets[index];
+                            return PickupQueueCard(
+                              ticket: ticket,
+                              timeFormat: timeFormat,
+                              onValidate: () =>
+                                  controller.validatePickup(ticket),
+                            );
+                          },
+                        ),
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- update the admin pickup queue view to read the reactive ticket list directly within the Obx builder so it refreshes automatically
- apply the same reactive rebuild pattern to the teacher pickup queue view to eliminate the need for manual refreshes

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d5ee05b5b483319cc3a5860bbc984b