### PR TITLE
Enable core library desugaring for Android build

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -14,6 +14,7 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
+        coreLibraryDesugaringEnabled = true
     }
 
     kotlinOptions {
@@ -47,6 +48,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:34.0.0')
     implementation 'com.google.firebase:firebase-auth'
     implementation 'com.google.firebase:firebase-firestore'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 }
 
 tasks.withType(JavaCompile).configureEach {


### PR DESCRIPTION
## Summary
- enable core library desugaring in the Android app module configuration
- add the desugar JDK libs dependency required by flutter_local_notifications

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d6c3edcbf48331972ca8d484614f1d