### PR TITLE
Handle missing dotenv initialization in AppConfig

### DIFF
--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -1,6 +1,17 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConfig {
-  static String get apiBaseUrl => dotenv.env['API_URL'] ?? '';
-  static String get apiKey => dotenv.env['API_KEY'] ?? '';
+  static String get apiBaseUrl => _readEnv('API_URL');
+  static String get apiKey => _readEnv('API_KEY');
+
+  static String _readEnv(String key) {
+    if (dotenv.isInitialized) {
+      return dotenv.env[key] ?? '';
+    }
+
+    // Fall back to compile-time environment variables so the app can
+    // still run (for example during tests) even if dotenv hasn't been
+    // loaded yet.
+    return const String.fromEnvironment(key, defaultValue: '');
+  }
 }


### PR DESCRIPTION
## Summary
- guard AppConfig accessors against an uninitialised dotenv instance
- add compile-time environment fallbacks so messaging setup can proceed without dotenv

## Testing
- flutter test *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d707e3362c8331b017ad7d164ff5eb