### PR TITLE
Fix environment fallback lookup

### DIFF
--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -12,6 +12,6 @@ class AppConfig {
     // Fall back to compile-time environment variables so the app can
     // still run (for example during tests) even if dotenv hasn't been
     // loaded yet.
-    return const String.fromEnvironment(key, defaultValue: '');
+    return String.fromEnvironment(key, defaultValue: '');
   }
 }


### PR DESCRIPTION
## Summary
- remove the const invocation when reading compile-time environment variables so runtime keys are accepted

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d70884fa848331a237dd17fa8c32c5