### PR TITLE
Update Android notification icon reference

### DIFF
--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -159,7 +159,7 @@ class MessagingService extends GetxService {
 
   Future<void> _setupLocalNotifications() async {
     const initializationSettingsAndroid =
-        AndroidInitializationSettings('@mipmap/ic_launcher');
+        AndroidInitializationSettings('@mipmap/launcher_icon');
     const initializationSettingsDarwin = DarwinInitializationSettings();
     const initializationSettings = InitializationSettings(
       android: initializationSettingsAndroid,


### PR DESCRIPTION
## Summary
- update the Android local notification initialization to reference the existing launcher icon

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d70b89a1c083319441214f3d23e029