### PR TITLE
Add messaging shortcut card to dashboards

### DIFF
--- a/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
+++ b/lib/modules/admin_dashboard/views/admin_dashboard_view.dart
@@ -16,6 +16,13 @@ class AdminDashboard extends StatelessWidget {
       onLogout: _controller.logout,
       cards: [
         DashboardCard(
+          icon: Icons.message,
+          title: 'Messages',
+          subtitle: 'Stay connected',
+          color: Colors.cyan,
+          onTap: () => Get.toNamed(AppPages.MESSAGING),
+        ),
+        DashboardCard(
           icon: Icons.announcement,
           title: 'Announcements',
           subtitle: 'School notices',

--- a/lib/modules/parents_dashboard/views/parent_dashboard_view.dart
+++ b/lib/modules/parents_dashboard/views/parent_dashboard_view.dart
@@ -16,6 +16,13 @@ class ParentDashboard extends StatelessWidget {
       onLogout: _controller.logout,
       cards: [
         DashboardCard(
+          icon: Icons.message,
+          title: 'Messages',
+          subtitle: 'Reach the school',
+          color: Colors.cyan,
+          onTap: () => Get.toNamed(AppPages.MESSAGING),
+        ),
+        DashboardCard(
           icon: Icons.announcement,
           title: 'Announcements',
           subtitle: 'School notices',

--- a/lib/modules/teachers_dashboard/views/teacher_dashboard_view.dart
+++ b/lib/modules/teachers_dashboard/views/teacher_dashboard_view.dart
@@ -16,6 +16,13 @@ class TeacherDashboard extends StatelessWidget {
       onLogout: _controller.logout,
       cards: [
         DashboardCard(
+          icon: Icons.message,
+          title: 'Messages',
+          subtitle: 'Chat with families',
+          color: Colors.cyan,
+          onTap: () => Get.toNamed(AppPages.MESSAGING),
+        ),
+        DashboardCard(
           icon: Icons.menu_book,
           title: 'Courses',
           subtitle: 'Create and share lessons',


### PR DESCRIPTION
## Summary
- add a reusable messaging shortcut card to the admin, teacher, and parent dashboards so users can jump into their inbox

## Testing
- flutter analyze *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d7170545108331b7848c1f775bd8bb