### PR TITLE
Normalize API base URL configuration

### DIFF
--- a/lib/app/config/app_config.dart
+++ b/lib/app/config/app_config.dart
@@ -1,7 +1,24 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AppConfig {
-  static String get apiBaseUrl => _readEnv('API_URL');
+  /// Returns the configured base URL for the HTTP API.
+  ///
+  /// The value is read from the `API_URL` environment variable which can be
+  /// provided either through a `.env` file (via `flutter_dotenv`) or using
+  /// compile-time `--dart-define` values. Because it is easy to accidentally
+  /// omit the URL scheme when configuring the value (e.g. providing
+  /// `api.example.com` instead of `https://api.example.com`), the result is
+  /// normalised before being returned so that the networking layer always
+  /// receives a valid absolute URL with a host.
+  static String get apiBaseUrl {
+    final raw = _readEnv('API_URL').trim();
+    if (raw.isEmpty) {
+      return '';
+    }
+
+    return _normaliseBaseUrl(raw);
+  }
+
   static String get apiKey => _readEnv('API_KEY');
 
   static String _readEnv(String key) {
@@ -13,5 +30,27 @@ class AppConfig {
     // still run (for example during tests) even if dotenv hasn't been
     // loaded yet.
     return String.fromEnvironment(key, defaultValue: '');
+  }
+
+  static String _normaliseBaseUrl(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return '';
+    }
+
+    final hasScheme = trimmed.startsWith(RegExp(r'https?://'));
+    final withScheme = hasScheme ? trimmed : 'https://$trimmed';
+
+    final uri = Uri.tryParse(withScheme);
+    if (uri == null || uri.host.isEmpty) {
+      throw FormatException(
+        'API_URL must be a valid absolute URL that includes a host.',
+        value,
+      );
+    }
+
+    final trimmedPath = uri.path.replaceAll(RegExp(r'/+$'), '');
+    final normalisedUri = uri.replace(path: trimmedPath);
+    return normalisedUri.toString();
   }
 }

--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -44,10 +44,27 @@ class MessagingService extends GetxService {
   Stream<MessageModel> get messageStream => _messageStreamController.stream;
 
   Future<MessagingService> init() async {
+    late final String baseUrl;
+    try {
+      baseUrl = AppConfig.apiBaseUrl;
+    } on FormatException catch (error) {
+      throw StateError(
+        'Invalid API_URL configuration: ${error.message}. Provide a full '
+        'URL that includes the protocol and host.',
+      );
+    }
+
+    if (baseUrl.isEmpty) {
+      throw StateError(
+        'Missing API_URL configuration. Please set the messaging API base '
+        'URL in your environment (e.g. via a .env file or --dart-define).',
+      );
+    }
+
     _dio = _providedDio ??
         Dio(
           BaseOptions(
-            baseUrl: AppConfig.apiBaseUrl,
+            baseUrl: baseUrl,
             connectTimeout: const Duration(seconds: 15),
             receiveTimeout: const Duration(seconds: 15),
             receiveDataWhenStatusError: true,


### PR DESCRIPTION
## Summary
- normalise the API_URL environment value so the messaging client always receives a fully qualified base URL
- surface clear errors during messaging service initialisation when the API URL is missing or invalid instead of performing host-less requests

## Testing
- not run (flutter is not installed in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d731c36f608331ad961fedc0db1883