### PR TITLE
Fix messaging view class closure

### DIFF
--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -914,6 +914,8 @@ class _ConversationThread extends StatelessWidget {
       );
     });
   }
+}
+
 class _MessageComposer extends StatelessWidget {
   const _MessageComposer({required this.controller});
 


### PR DESCRIPTION
## Summary
- close the `_ConversationThread` class before defining `_MessageComposer` to restore valid syntax

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc21a1bbc08331bf74bb1e46260dcb