### PR TITLE
Enable realtime updates for messaging conversations

### DIFF
--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -159,6 +159,25 @@ class MessagingService extends GetxService {
     }
   }
 
+  Stream<List<ConversationModel>> watchConversations() {
+    final userId = _authService.currentUser?.uid;
+    if (userId == null) {
+      return Stream<List<ConversationModel>>.value(<ConversationModel>[]);
+    }
+
+    return _firestore
+        .collection(_conversationsCollection)
+        .where('participantIds', arrayContains: userId)
+        .snapshots()
+        .map((snapshot) {
+      final conversations = snapshot.docs
+          .map((doc) => _conversationFromData(doc.id, doc.data()))
+          .toList();
+      conversations.sort((a, b) => b.updatedAt.compareTo(a.updatedAt));
+      return conversations;
+    });
+  }
+
   Future<ConversationModel?> fetchConversation(String conversationId) async {
     try {
       final doc = await _firestore


### PR DESCRIPTION
## Summary
- add a Firestore-backed stream in the messaging service to observe conversation changes
- subscribe the messaging controller to the conversation stream so chat lists update automatically

## Testing
- Not run (Flutter SDK is not available in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68dc2ce1cc8083319ad91bfe7c62811c