### PR TITLE
Improve messaging composer and notification prompts

### DIFF
--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -1050,6 +1050,16 @@ class MessagingService extends GetxService {
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>();
     await androidPlugin?.createNotificationChannel(_androidChannel);
+    await androidPlugin?.requestNotificationsPermission();
+
+    final darwinPlugin = _localNotifications
+        .resolvePlatformSpecificImplementation<
+            DarwinFlutterLocalNotificationsPlugin>();
+    await darwinPlugin?.requestPermissions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
   }
 
   void _handleForegroundMessage(RemoteMessage message) {

--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -856,40 +856,41 @@ class _MessageComposer extends StatelessWidget {
       top: false,
       child: Padding(
         padding: const EdgeInsets.fromLTRB(16, 8, 16, 16),
-        child: DecoratedBox(
-          decoration: BoxDecoration(
-            color: theme.colorScheme.surface,
-            borderRadius: BorderRadius.circular(28),
-            boxShadow: [
-              BoxShadow(
-                color: theme.shadowColor.withOpacity(0.08),
-                blurRadius: 16,
-                offset: const Offset(0, 8),
-              ),
-            ],
-          ),
+        child: Material(
+          color: theme.colorScheme.surface,
+          elevation: 6,
+          borderRadius: BorderRadius.circular(28),
           child: Padding(
-            padding: const EdgeInsets.fromLTRB(16, 10, 12, 10),
+            padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
             child: Row(
-              crossAxisAlignment: CrossAxisAlignment.end,
+              crossAxisAlignment: CrossAxisAlignment.center,
               children: [
                 Expanded(
-                  child: Container(
+                  child: DecoratedBox(
                     decoration: BoxDecoration(
-                      color: theme.colorScheme.surfaceVariant.withOpacity(0.35),
+                      color:
+                          theme.colorScheme.surfaceVariant.withOpacity(0.35),
                       borderRadius: BorderRadius.circular(20),
                     ),
-                    padding: const EdgeInsets.symmetric(horizontal: 16),
-                    child: TextField(
-                      controller: controller.composerController,
-                      minLines: 1,
-                      maxLines: 5,
-                      textInputAction: TextInputAction.send,
-                      decoration: const InputDecoration(
-                        hintText: 'Write a message…',
-                        border: InputBorder.none,
+                    child: ConstrainedBox(
+                      constraints: const BoxConstraints(minHeight: 44),
+                      child: Padding(
+                        padding: const EdgeInsets.symmetric(horizontal: 16),
+                        child: TextField(
+                          controller: controller.composerController,
+                          minLines: 1,
+                          maxLines: 6,
+                          textAlignVertical: TextAlignVertical.center,
+                          keyboardType: TextInputType.multiline,
+                          textCapitalization: TextCapitalization.sentences,
+                          textInputAction: TextInputAction.send,
+                          decoration: const InputDecoration(
+                            hintText: 'Write a message…',
+                            border: InputBorder.none,
+                          ),
+                          onSubmitted: (_) => controller.sendCurrentMessage(),
+                        ),
                       ),
-                      onSubmitted: (_) => controller.sendCurrentMessage(),
                     ),
                   ),
                 ),


### PR DESCRIPTION
## Summary
- refresh the conversation composer styling with a taller multiline text field and balanced alignment
- request runtime notification permissions for Android and iOS so foreground pushes can be displayed

## Testing
- not run (environment missing Flutter/Dart SDK)


------
https://chatgpt.com/codex/tasks/task_e_68dc305f3ae48331a8944bb5fa647aef