### PR TITLE
Fix iOS local notification permission request

### DIFF
--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -1052,10 +1052,10 @@ class MessagingService extends GetxService {
     await androidPlugin?.createNotificationChannel(_androidChannel);
     await androidPlugin?.requestNotificationsPermission();
 
-    final darwinPlugin = _localNotifications
+    final iosPlugin = _localNotifications
         .resolvePlatformSpecificImplementation<
-            DarwinFlutterLocalNotificationsPlugin>();
-    await darwinPlugin?.requestPermissions(
+            IOSFlutterLocalNotificationsPlugin>();
+    await iosPlugin?.requestPermissions(
       alert: true,
       badge: true,
       sound: true,


### PR DESCRIPTION
## Summary
- replace the Darwin-specific local notifications plugin type with the iOS implementation
- keep the push permission request working on environments without the Darwin class

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dc319e4b808331addd0be722f8d3a6