### PR TITLE
Add Flutter local notifications for background chat messages

### DIFF
--- a/lib/modules/messaging/services/messaging_notification_channel.dart
+++ b/lib/modules/messaging/services/messaging_notification_channel.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+const AndroidNotificationChannel messagingAndroidChannel = AndroidNotificationChannel(
+  'messaging_channel',
+  'Messaging notifications',
+  description: 'Notifications for new chat messages.',
+  importance: Importance.high,
+);
+
+const DarwinNotificationDetails messagingDarwinNotificationDetails = DarwinNotificationDetails(
+  presentAlert: true,
+  presentBadge: true,
+  presentSound: true,
+);

--- a/lib/modules/messaging/services/messaging_push_handler.dart
+++ b/lib/modules/messaging/services/messaging_push_handler.dart
@@ -1,10 +1,64 @@
+import 'dart:convert';
 import 'dart:developer';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+
+import 'messaging_notification_channel.dart';
+
+final FlutterLocalNotificationsPlugin _backgroundNotifications =
+    FlutterLocalNotificationsPlugin();
+
+bool _backgroundNotificationsInitialized = false;
 
 @pragma('vm:entry-point')
 Future<void> messagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
+  DartPluginRegistrant.ensureInitialized();
+
+  if (!_backgroundNotificationsInitialized) {
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/launcher_icon'),
+      iOS: DarwinInitializationSettings(),
+    );
+
+    await _backgroundNotifications.initialize(initializationSettings);
+
+    final androidPlugin = _backgroundNotifications
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>();
+    await androidPlugin?.createNotificationChannel(messagingAndroidChannel);
+
+    _backgroundNotificationsInitialized = true;
+  }
+
+  final notification = message.notification;
+  final data = message.data;
+
+  await _backgroundNotifications.show(
+    notification?.hashCode ?? DateTime.now().millisecondsSinceEpoch,
+    notification?.title ?? data['title'] ?? 'New message',
+    notification?.body ?? data['content'] ?? data['text'] ?? '',
+    NotificationDetails(
+      android: AndroidNotificationDetails(
+        messagingAndroidChannel.id,
+        messagingAndroidChannel.name,
+        channelDescription: messagingAndroidChannel.description,
+        importance: Importance.high,
+        priority: Priority.high,
+        styleInformation: const DefaultStyleInformation(true, true),
+      ),
+      iOS: messagingDarwinNotificationDetails,
+    ),
+    payload: jsonEncode(<String, dynamic>{
+      ...data,
+      if (!data.containsKey('conversationId') &&
+          data['conversation_id'] != null)
+        'conversationId': data['conversation_id'],
+    }),
+  );
+
   log('Received background message ${message.messageId}: ${message.data}');
 }

--- a/lib/modules/messaging/services/messaging_service.dart
+++ b/lib/modules/messaging/services/messaging_service.dart
@@ -16,6 +16,7 @@ import '../../../core/services/auth_service.dart';
 import '../../../data/models/conversation_model.dart';
 import '../../../data/models/message_model.dart';
 import '../../../data/models/messaging_contact.dart';
+import 'messaging_notification_channel.dart';
 import 'messaging_push_handler.dart';
 
 class MessagingService extends GetxService {
@@ -47,14 +48,6 @@ class MessagingService extends GetxService {
   String? _pendingToken;
   String? _lastKnownUserId;
   bool _pushPermissionGranted = false;
-
-  static const AndroidNotificationChannel _androidChannel =
-      AndroidNotificationChannel(
-    'messaging_channel',
-    'Messaging notifications',
-    description: 'Notifications for new chat messages.',
-    importance: Importance.high,
-  );
 
   static const String _messagingRoute = '/messaging';
   static const String _tokenCollection = 'userPushTokens';
@@ -1049,7 +1042,7 @@ class MessagingService extends GetxService {
     final androidPlugin = _localNotifications
         .resolvePlatformSpecificImplementation<
             AndroidFlutterLocalNotificationsPlugin>();
-    await androidPlugin?.createNotificationChannel(_androidChannel);
+    await androidPlugin?.createNotificationChannel(messagingAndroidChannel);
     await androidPlugin?.requestNotificationsPermission();
 
     final iosPlugin = _localNotifications
@@ -1127,18 +1120,14 @@ class MessagingService extends GetxService {
       notification?.body ?? data['content'] ?? data['text'] ?? '',
       NotificationDetails(
         android: AndroidNotificationDetails(
-          _androidChannel.id,
-          _androidChannel.name,
-          channelDescription: _androidChannel.description,
+          messagingAndroidChannel.id,
+          messagingAndroidChannel.name,
+          channelDescription: messagingAndroidChannel.description,
           importance: Importance.high,
           priority: Priority.high,
           styleInformation: const DefaultStyleInformation(true, true),
         ),
-        iOS: const DarwinNotificationDetails(
-          presentAlert: true,
-          presentBadge: true,
-          presentSound: true,
-        ),
+        iOS: messagingDarwinNotificationDetails,
       ),
       payload: jsonEncode(<String, dynamic>{
         ...data,


### PR DESCRIPTION
## Summary
- share reusable notification channel constants for messaging alerts
- initialize flutter_local_notifications inside the background FCM handler
- display a local notification when chat messages arrive in the background

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc6695a2f483318992556643c50580