### PR TITLE
Fix background handler initialization

### DIFF
--- a/lib/modules/messaging/services/messaging_push_handler.dart
+++ b/lib/modules/messaging/services/messaging_push_handler.dart
@@ -16,7 +16,7 @@ bool _backgroundNotificationsInitialized = false;
 @pragma('vm:entry-point')
 Future<void> messagingBackgroundHandler(RemoteMessage message) async {
   await Firebase.initializeApp();
-  DartPluginRegistrant.ensureInitialized();
+  WidgetsFlutterBinding.ensureInitialized();
 
   if (!_backgroundNotificationsInitialized) {
     const initializationSettings = InitializationSettings(


### PR DESCRIPTION
## Summary
- replace the Dart plugin registrant call in the background messaging handler with a standard widget binding initialization to avoid undefined identifier errors on devices where `DartPluginRegistrant` is unavailable

## Testing
- flutter analyze (fails: Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dc67afd7ac8331bbdd7674cf7fdf86