### PR TITLE
Fix push notifications by aligning messaging participants with user IDs

### DIFF
--- a/lib/data/models/conversation_model.dart
+++ b/lib/data/models/conversation_model.dart
@@ -83,18 +83,24 @@ class ConversationParticipant {
     required this.id,
     required this.name,
     required this.role,
-  });
+    String? userId,
+  }) : userId = userId ?? id;
 
   final String id;
   final String name;
   final String role;
+  final String userId;
 
   factory ConversationParticipant.fromJson(Map<String, dynamic> json) {
+    final rawId = (json['id'] ?? json['userId'] ?? '').toString();
+    final resolvedUserId =
+        (json['userId'] ?? json['uid'] ?? rawId).toString();
     return ConversationParticipant(
-      id: (json['id'] ?? json['userId'] ?? '') as String,
+      id: rawId,
       name: (json['name'] ?? json['displayName'] ?? json['email'] ?? 'User')
           as String,
       role: (json['role'] ?? 'user') as String,
+      userId: resolvedUserId,
     );
   }
 }

--- a/lib/data/models/messaging_contact.dart
+++ b/lib/data/models/messaging_contact.dart
@@ -3,23 +3,29 @@ class MessagingContact {
     required this.id,
     required this.name,
     required this.role,
+    String? userId,
     this.classIds = const <String>[],
     this.relationship,
-  });
+  }) : userId = userId ?? id;
 
   final String id;
   final String name;
   final String role;
+  final String userId;
   final List<String> classIds;
   final String? relationship;
 
   factory MessagingContact.fromJson(Map<String, dynamic> json) {
     final classes = json['classIds'] ?? json['class_ids'];
+    final rawId = (json['id'] ?? json['userId'] ?? '').toString();
+    final resolvedUserId =
+        (json['userId'] ?? json['uid'] ?? rawId).toString();
     return MessagingContact(
-      id: (json['id'] ?? json['userId'] ?? '') as String,
+      id: rawId,
       name: (json['name'] ?? json['displayName'] ?? json['email'] ?? 'User')
           as String,
       role: (json['role'] ?? 'user') as String,
+      userId: resolvedUserId,
       classIds: classes is List
           ? classes.whereType<String>().toList()
           : const <String>[],
@@ -31,6 +37,7 @@ class MessagingContact {
     String? id,
     String? name,
     String? role,
+    String? userId,
     List<String>? classIds,
     String? relationship,
   }) {
@@ -38,6 +45,7 @@ class MessagingContact {
       id: id ?? this.id,
       name: name ?? this.name,
       role: role ?? this.role,
+      userId: userId ?? this.userId,
       classIds: classIds ?? this.classIds,
       relationship: relationship ?? this.relationship,
     );


### PR DESCRIPTION
## Summary
- add a stable `userId` field to messaging contacts and conversation participants
- update the messaging service to store those IDs in Firestore and use them when resolving recipients and unread counters
- teach the messaging controller to prefer the stored user IDs when matching contacts and labelling conversations

## Testing
- Not run (Flutter/Dart tooling unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dc68de76e48331aca9c8b87bba49a5