### PR TITLE
Add Android 13 notification permission

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,10 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <!-- Required for showing notifications on Android 13+ -->
+    <uses-permission
+        android:name="android.permission.POST_NOTIFICATIONS"
+        tools:targetApi="33" />
 
     <application
         android:label="EduMS"


### PR DESCRIPTION
## Summary
- add the POST_NOTIFICATIONS permission so FCM alerts can show on Android 13+

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dc774e5da083319d9f3cd3e4947f5b