### PR TITLE
Fix missing closing brace in MessagingView

### DIFF
--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -178,7 +178,7 @@ class MessagingView extends GetView<MessagingController> {
     });
 
   }
-
+}
 
 
 class _NewConversationView extends StatefulWidget {


### PR DESCRIPTION
## Summary
- add the missing closing brace for `MessagingView` so helper widgets are correctly defined at top level

## Testing
- not run (Flutter SDK is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68dca1a779908331b417f6bb46fe84d5