### PR TITLE
Configure Android network security for Firestore connectivity

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,9 @@
     <application
         android:label="EduMS"
         android:name="${applicationName}"
-        android:icon="@mipmap/launcher_icon">
+        android:icon="@mipmap/launcher_icon"
+        android:usesCleartextTraffic="true"
+        android:networkSecurityConfig="@xml/network_security_config">
         <activity
             android:name=".MainActivity"
             android:exported="true"

--- a/android/app/src/main/res/xml/network_security_config.xml
+++ b/android/app/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="true">firestore.googleapis.com</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary
- allow the Android application to permit cleartext traffic so Firestore can be reached when DNS resolution fails
- add a network security configuration that explicitly permits access to firestore.googleapis.com

## Testing
- No tests were run (not supported in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68dd4c84d3348331a7788b4d8124d4a1