### PR TITLE
Add connectivity monitoring to stabilize Firestore offline behavior

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="29" />
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />

--- a/lib/app/bindings/app-binding.dart
+++ b/lib/app/bindings/app-binding.dart
@@ -3,6 +3,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../core/services/auth_service.dart';
 import '../../core/services/database_service.dart';
+import '../../core/services/network_service.dart';
 import '../../modules/admin_dashboard/controllers/admin_controller.dart';
 import '../../modules/admin_dashboard/controllers/admin_control_controller.dart';
 import '../../modules/attendance/controllers/admin_attendance_controller.dart';
@@ -37,6 +38,11 @@ class AppBindings extends Bindings {
     // Initialize SharedPreferences
     final prefs = await SharedPreferences.getInstance();
     Get.put(prefs, permanent: true);
+
+    // Monitor connectivity for Firestore before other services use it
+    final networkService = NetworkService();
+    await networkService.init();
+    Get.put(networkService, permanent: true);
 
     // Initialize DatabaseService
     final databaseService = DatabaseService();

--- a/lib/core/services/network_service.dart
+++ b/lib/core/services/network_service.dart
@@ -1,0 +1,54 @@
+import 'dart:async';
+
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:get/get.dart';
+
+class NetworkService extends GetxService {
+  NetworkService({Connectivity? connectivity})
+      : _connectivity = connectivity ?? Connectivity();
+
+  final Connectivity _connectivity;
+  final RxBool _isOnline = true.obs;
+  StreamSubscription<ConnectivityResult>? _subscription;
+
+  bool get isOnline => _isOnline.value;
+
+  Future<void> init() async {
+    final status = await _connectivity.checkConnectivity();
+    await _handleStatusChange(status, initial: true);
+
+    _subscription =
+        _connectivity.onConnectivityChanged.listen(_handleStatusChange);
+  }
+
+  Future<void> _handleStatusChange(ConnectivityResult status,
+      {bool initial = false}) async {
+    final connected = status != ConnectivityResult.none;
+
+    if (!initial && connected == _isOnline.value) {
+      return;
+    }
+
+    _isOnline.value = connected;
+
+    try {
+      if (connected) {
+        await FirebaseFirestore.instance.enableNetwork();
+      } else {
+        await FirebaseFirestore.instance.disableNetwork();
+      }
+    } catch (error) {
+      // Ignore errors caused by repeated enable/disable calls.
+      if (Get.isLogEnable) {
+        Get.log('Network toggle failed: $error');
+      }
+    }
+  }
+
+  @override
+  void onClose() {
+    _subscription?.cancel();
+    super.onClose();
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,6 +21,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   shared_preferences: ^2.5.3
   url_launcher: ^6.3.2
+  connectivity_plus: ^6.0.5
   flutter_dotenv: ^5.2.1
   animated_splash_screen: ^1.3.0
   intl: ^0.19.0


### PR DESCRIPTION
## Summary
- add a connectivity_plus dependency and a NetworkService that toggles the Firestore network layer based on connectivity events
- initialize the NetworkService during core service setup so Firestore stays offline while the device has no internet
- request the ACCESS_NETWORK_STATE permission required for connectivity monitoring

## Testing
- not run (flutter not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd4e023d848331b1ad672063029557