### PR TITLE
Handle new connectivity_plus status types

### DIFF
--- a/lib/core/services/network_service.dart
+++ b/lib/core/services/network_service.dart
@@ -10,21 +10,28 @@ class NetworkService extends GetxService {
 
   final Connectivity _connectivity;
   final RxBool _isOnline = true.obs;
-  StreamSubscription<ConnectivityResult>? _subscription;
+  StreamSubscription<dynamic>? _subscription;
 
   bool get isOnline => _isOnline.value;
 
   Future<void> init() async {
     final status = await _connectivity.checkConnectivity();
-    await _handleStatusChange(status as ConnectivityResult, initial: true);
+    await _handleStatusChange(status, initial: true);
 
     _subscription =
-        _connectivity.onConnectivityChanged.listen(_handleStatusChange as void Function(List<ConnectivityResult> event)?) as StreamSubscription<ConnectivityResult>?;
+        _connectivity.onConnectivityChanged.listen(_handleStatusChange);
   }
 
-  Future<void> _handleStatusChange(ConnectivityResult status,
+  Future<void> _handleStatusChange(dynamic status,
       {bool initial = false}) async {
-    final connected = status != ConnectivityResult.none;
+    final connected = _isConnected(status);
+
+    if (connected == null) {
+      if (Get.isLogEnable) {
+        Get.log('Unknown connectivity status type: ${status.runtimeType}');
+      }
+      return;
+    }
 
     if (!initial && connected == _isOnline.value) {
       return;
@@ -44,6 +51,18 @@ class NetworkService extends GetxService {
         Get.log('Network toggle failed: $error');
       }
     }
+  }
+
+  bool? _isConnected(dynamic status) {
+    if (status is ConnectivityResult) {
+      return status != ConnectivityResult.none;
+    }
+
+    if (status is List<ConnectivityResult>) {
+      return status.any((result) => result != ConnectivityResult.none);
+    }
+
+    return null;
   }
 
   @override


### PR DESCRIPTION
## Summary
- adapt the network service to the connectivity_plus 6.x API which emits lists of ConnectivityResult values
- centralize connectivity parsing and add logging for unexpected status payloads

## Testing
- not run (Flutter SDK is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd511cd91483319e540205fa9ec300