### PR TITLE
Implement modal conversation popup and update login screen

### DIFF
--- a/lib/modules/auth/views/login_view.dart
+++ b/lib/modules/auth/views/login_view.dart
@@ -15,117 +15,140 @@ class LoginView extends StatelessWidget {
     return GestureDetector(
       onTap: _authController.unfocusFields,
       child: Scaffold(
-        body: Center(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.all(24),
-            child: ConstrainedBox(
-              constraints: const BoxConstraints(maxWidth: 400),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset('assets/EduMS_logo.png', width: 200, height: 200),
-                  const SizedBox(height: 40),
-
-                  Card(
-                    elevation: 2,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(16),
-                    ),
-                    child: Padding(
-                      padding: const EdgeInsets.all(24),
-                      child: Column(
-                        children: [
-                          Text(
-                            'Login',
-                            style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                              fontWeight: FontWeight.bold,
-                              color: Theme.of(context).colorScheme.primary,
+        body: Container(
+          decoration: const BoxDecoration(
+            image: DecorationImage(
+              image: AssetImage('assets/splash/background.png'),
+              fit: BoxFit.cover,
+            ),
+          ),
+          child: Center(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.all(24),
+              child: ConstrainedBox(
+                constraints: const BoxConstraints(maxWidth: 400),
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Image.asset('assets/EduMS_logo.png', width: 200, height: 200),
+                    const SizedBox(height: 40),
+                    Card(
+                      elevation: 2,
+                      shape: RoundedRectangleBorder(
+                        borderRadius: BorderRadius.circular(16),
+                      ),
+                      child: Padding(
+                        padding: const EdgeInsets.all(24),
+                        child: Column(
+                          children: [
+                            Text(
+                              'Login',
+                              style: Theme.of(context)
+                                  .textTheme
+                                  .headlineMedium
+                                  ?.copyWith(
+                                    fontWeight: FontWeight.bold,
+                                    color: Theme.of(context).colorScheme.primary,
+                                  ),
                             ),
-                          ),
-                          const SizedBox(height: 24),
-
-                          TextField(
-                            controller: _authController.emailController,
-                            focusNode: _authController.emailFocus,
-                            decoration: InputDecoration(
-                              labelText: 'Email',
-                              prefixIcon: Icon(Icons.email,
-                                  color: Theme.of(context).colorScheme.onSurfaceVariant),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              filled: true,
-                              fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.4),
-                            ),
-                            keyboardType: TextInputType.emailAddress,
-                            textInputAction: TextInputAction.next,
-                            onSubmitted: (_) => _authController.passwordFocus.requestFocus(),
-                          ),
-                          const SizedBox(height: 16),
-
-                          Obx(() => TextField(
-                            controller: _authController.passwordController,
-                            focusNode: _authController.passwordFocus,
-                            obscureText: _obscurePassword.value,
-                            decoration: InputDecoration(
-                              labelText: 'Password',
-                              prefixIcon: Icon(Icons.lock,
-                                  color: Theme.of(context).colorScheme.onSurfaceVariant),
-                              suffixIcon: IconButton(
-                                icon: Icon(
-                                  _obscurePassword.value ? Icons.visibility : Icons.visibility_off,
-                                  color: Theme.of(context).colorScheme.onSurfaceVariant,
+                            const SizedBox(height: 24),
+                            TextField(
+                              controller: _authController.emailController,
+                              focusNode: _authController.emailFocus,
+                              decoration: InputDecoration(
+                                labelText: 'Email',
+                                prefixIcon: Icon(
+                                  Icons.email,
+                                  color:
+                                      Theme.of(context).colorScheme.onSurfaceVariant,
                                 ),
-                                onPressed: () => _obscurePassword.toggle(),
+                                border: OutlineInputBorder(
+                                  borderRadius: BorderRadius.circular(12),
+                                ),
+                                filled: true,
+                                fillColor: Theme.of(context)
+                                    .colorScheme
+                                    .surfaceVariant
+                                    .withOpacity(0.4),
                               ),
-                              border: OutlineInputBorder(
-                                borderRadius: BorderRadius.circular(12),
-                              ),
-                              filled: true,
-                              fillColor: Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.4),
+                              keyboardType: TextInputType.emailAddress,
+                              textInputAction: TextInputAction.next,
+                              onSubmitted: (_) =>
+                                  _authController.passwordFocus.requestFocus(),
                             ),
-                            textInputAction: TextInputAction.done,
-                            onSubmitted: (_) => _authController.submitForm(),
-                          )),
-                          const SizedBox(height: 24),
-
-                          Obx(() => FilledButton(
-                            style: FilledButton.styleFrom(
-                              backgroundColor: Theme.of(context).colorScheme.primary,
-                              foregroundColor: Theme.of(context).colorScheme.onPrimary,
-                              minimumSize: const Size(double.infinity, 50),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(12),
+                            const SizedBox(height: 16),
+                            Obx(
+                              () => TextField(
+                                controller: _authController.passwordController,
+                                focusNode: _authController.passwordFocus,
+                                obscureText: _obscurePassword.value,
+                                decoration: InputDecoration(
+                                  labelText: 'Password',
+                                  prefixIcon: Icon(
+                                    Icons.lock,
+                                    color: Theme.of(context)
+                                        .colorScheme
+                                        .onSurfaceVariant,
+                                  ),
+                                  suffixIcon: IconButton(
+                                    icon: Icon(
+                                      _obscurePassword.value
+                                          ? Icons.visibility
+                                          : Icons.visibility_off,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
+                                    ),
+                                    onPressed: () => _obscurePassword.toggle(),
+                                  ),
+                                  border: OutlineInputBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                  filled: true,
+                                  fillColor: Theme.of(context)
+                                      .colorScheme
+                                      .surfaceVariant
+                                      .withOpacity(0.4),
+                                ),
+                                textInputAction: TextInputAction.done,
+                                onSubmitted: (_) => _authController.submitForm(),
                               ),
                             ),
-                            onPressed: _authController.isLoading.value ? null : _authController.submitForm,
-                            child: _authController.isLoading.value
-                                ? const SizedBox(
-                              height: 24,
-                              width: 24,
-                              child: CircularProgressIndicator(
-                                strokeWidth: 2,
-                                color: Colors.white,
-                              ),
-                            )
-                                : const Text('Login', style: TextStyle(fontSize: 16)),
-                          )),
-
-                          const SizedBox(height: 16),
-                          TextButton(
-                            onPressed: () => Get.toNamed('/register'),
-                            child: Text(
-                              'Create Admin Account',
-                              style: TextStyle(
-                                color: Theme.of(context).colorScheme.primary,
+                            const SizedBox(height: 24),
+                            Obx(
+                              () => FilledButton(
+                                style: FilledButton.styleFrom(
+                                  backgroundColor:
+                                      Theme.of(context).colorScheme.primary,
+                                  foregroundColor:
+                                      Theme.of(context).colorScheme.onPrimary,
+                                  minimumSize: const Size(double.infinity, 50),
+                                  shape: RoundedRectangleBorder(
+                                    borderRadius: BorderRadius.circular(12),
+                                  ),
+                                ),
+                                onPressed: _authController.isLoading.value
+                                    ? null
+                                    : _authController.submitForm,
+                                child: _authController.isLoading.value
+                                    ? const SizedBox(
+                                        height: 24,
+                                        width: 24,
+                                        child: CircularProgressIndicator(
+                                          strokeWidth: 2,
+                                          color: Colors.white,
+                                        ),
+                                      )
+                                    : const Text('Login',
+                                        style: TextStyle(fontSize: 16)),
                               ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
                     ),
-                  ),
-                ],
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/modules/messaging/controllers/messaging_controller.dart
+++ b/lib/modules/messaging/controllers/messaging_controller.dart
@@ -13,7 +13,6 @@ import '../services/messaging_service.dart';
 
 enum MessagingViewMode {
   conversationList,
-  newConversation,
   conversationThread,
 }
 
@@ -358,10 +357,6 @@ class MessagingController extends GetxController {
 
   void showConversationListView() {
     activeView.value = MessagingViewMode.conversationList;
-  }
-
-  void showNewConversationView() {
-    activeView.value = MessagingViewMode.newConversation;
   }
 
   Future<void> startConversationWithAdministration() async {

--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -21,14 +21,39 @@ class MessagingView extends GetView<MessagingController> {
       final viewMode = controller.activeView.value;
       final activeConversation = controller.activeConversation.value;
 
+      Future<void> openNewConversationDialog() async {
+        await showDialog<void>(
+          context: context,
+          barrierDismissible: true,
+          builder: (dialogContext) {
+            final mediaQuery = MediaQuery.of(dialogContext);
+            final size = mediaQuery.size;
+            final width = size.width * 0.95;
+            final dialogWidth = width > 640 ? 640.0 : width;
+            final heightLimit = size.height * 0.85;
+            final dialogHeight = heightLimit > 720 ? 720.0 : heightLimit;
+            return Dialog(
+              clipBehavior: Clip.antiAlias,
+              insetPadding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+              backgroundColor: theme.colorScheme.surface,
+              child: SizedBox(
+                width: dialogWidth,
+                height: dialogHeight,
+                child: NewConversationView(
+                  controller: controller,
+                  onClose: () => Navigator.of(dialogContext).pop(),
+                ),
+              ),
+            );
+          },
+        );
+      }
+
       return WillPopScope(
         onWillPop: () async {
           if (viewMode == MessagingViewMode.conversationThread) {
             controller.clearActiveConversation();
-            return false;
-          }
-          if (viewMode == MessagingViewMode.newConversation) {
-            controller.showConversationListView();
             return false;
           }
           return true;
@@ -45,13 +70,6 @@ class MessagingView extends GetView<MessagingController> {
                   icon: const Icon(Icons.arrow_back),
                   tooltip: 'Back to conversations',
                   onPressed: controller.clearActiveConversation,
-                );
-              }
-              if (viewMode == MessagingViewMode.newConversation) {
-                return IconButton(
-                  icon: const Icon(Icons.arrow_back),
-                  tooltip: 'Back to conversations',
-                  onPressed: controller.showConversationListView,
                 );
               }
               if (canPop) {
@@ -78,23 +96,6 @@ class MessagingView extends GetView<MessagingController> {
                       ),
                       Text(
                         'Stay connected with your school community',
-                        style: theme.textTheme.labelSmall?.copyWith(
-                          color: theme.colorScheme.onSurfaceVariant,
-                        ),
-                      ),
-                    ],
-                  );
-                case MessagingViewMode.newConversation:
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Text(
-                        'New message',
-                        style: theme.textTheme.titleMedium,
-                      ),
-                      Text(
-                        'Choose who you want to reach out to',
                         style: theme.textTheme.labelSmall?.copyWith(
                           color: theme.colorScheme.onSurfaceVariant,
                         ),
@@ -153,8 +154,6 @@ class MessagingView extends GetView<MessagingController> {
             switch (viewMode) {
               case MessagingViewMode.conversationList:
                 return ConversationHistoryView(controller: controller);
-              case MessagingViewMode.newConversation:
-                return NewConversationView(controller: controller);
               case MessagingViewMode.conversationThread:
                 if (activeConversation == null) {
                   return const ScrollablePlaceholder(
@@ -168,7 +167,7 @@ class MessagingView extends GetView<MessagingController> {
               viewMode == MessagingViewMode.conversationList
                   ? FloatingActionButton(
                       tooltip: 'Start a new conversation',
-                      onPressed: controller.showNewConversationView,
+                      onPressed: openNewConversationDialog,
                       child: const Icon(Icons.add_comment_rounded),
                     )
                   : null,

--- a/lib/modules/messaging/views/new_conversation_view.dart
+++ b/lib/modules/messaging/views/new_conversation_view.dart
@@ -5,9 +5,14 @@ import '../../common/widgets/module_empty_state.dart';
 import '../controllers/messaging_controller.dart';
 
 class NewConversationView extends StatefulWidget {
-  const NewConversationView({super.key, required this.controller});
+  const NewConversationView({
+    super.key,
+    required this.controller,
+    this.onClose,
+  });
 
   final MessagingController controller;
+  final VoidCallback? onClose;
 
   @override
   State<NewConversationView> createState() => _NewConversationViewState();
@@ -295,8 +300,11 @@ class _NewConversationViewState extends State<NewConversationView> {
                           color: Colors.transparent,
                           child: InkWell(
                             borderRadius: BorderRadius.circular(24),
-                            onTap: () =>
-                                _controller.startConversationWithContact(contact),
+                            onTap: () async {
+                              await _controller
+                                  .startConversationWithContact(contact);
+                              widget.onClose?.call();
+                            },
                             child: Ink(
                               decoration: BoxDecoration(
                                 borderRadius: BorderRadius.circular(24),


### PR DESCRIPTION
## Summary
- update the login screen to remove the create-admin entry point and show the splash background artwork
- open the new-conversation picker as a responsive dialog so the conversation list view keeps its filter UI
- allow the new conversation view to close the dialog once a recipient is selected

## Testing
- not run (Flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd5f3ba32483318ee782d0879ca473