### PR TITLE
Show conversation avatar in thread app bar

### DIFF
--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -118,21 +118,47 @@ class MessagingView extends GetView<MessagingController> {
                   }
                   final contextText =
                       controller.resolveConversationContext(activeConversation);
-                  return Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    mainAxisSize: MainAxisSize.min,
+                  final titleInitial = titleText.isEmpty
+                      ? '?'
+                      : titleText.characters.first.toUpperCase();
+                  return Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
                     children: [
-                      Text(
-                        titleText,
-                        style: theme.textTheme.titleMedium,
+                      CircleAvatar(
+                        radius: 20,
+                        backgroundColor: hasAdministrationParticipant
+                            ? Colors.transparent
+                            : theme.colorScheme.primary.withOpacity(0.12),
+                        foregroundColor: theme.colorScheme.primary,
+                        backgroundImage: hasAdministrationParticipant
+                            ? const AssetImage('assets/icon/icon.png')
+                            : null,
+                        child: hasAdministrationParticipant
+                            ? null
+                            : Text(titleInitial),
                       ),
-                      if (contextText != null && contextText.isNotEmpty)
-                        Text(
-                          contextText,
-                          style: theme.textTheme.labelSmall?.copyWith(
-                            color: theme.colorScheme.onSurfaceVariant,
-                          ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              titleText,
+                              style: theme.textTheme.titleMedium,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            if (contextText != null && contextText.isNotEmpty)
+                              Text(
+                                contextText,
+                                style: theme.textTheme.labelSmall?.copyWith(
+                                  color: theme.colorScheme.onSurfaceVariant,
+                                ),
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                          ],
                         ),
+                      ),
                     ],
                   );
               }


### PR DESCRIPTION
## Summary
- add a conversation avatar to the thread app bar by prepending a CircleAvatar to the title
- mirror the administration badge handling from the conversation list and ensure text overflow is handled

## Testing
- `flutter test` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddedbaa8f883319a237fa4b4b22b35