### PR TITLE
Fix admin avatars in messaging views

### DIFF
--- a/lib/modules/messaging/views/conversation_history_view.dart
+++ b/lib/modules/messaging/views/conversation_history_view.dart
@@ -100,10 +100,6 @@ class ConversationHistoryView extends StatelessWidget {
                   final titleInitial = displayTitle.isEmpty
                       ? '?'
                       : displayTitle.characters.first.toUpperCase();
-                  final hasAdministrationParticipant = conversation.participants
-                      .any((participant) =>
-                          participant.role.toLowerCase() == 'admin');
-
                   return AnimatedContainer(
                     duration: const Duration(milliseconds: 250),
                     curve: Curves.easeInOut,
@@ -127,16 +123,10 @@ class ConversationHistoryView extends StatelessWidget {
                         vertical: 12,
                       ),
                       leading: CircleAvatar(
-                        backgroundColor: hasAdministrationParticipant
-                            ? Colors.transparent
-                            : theme.colorScheme.primary.withOpacity(0.12),
+                        backgroundColor:
+                            theme.colorScheme.primary.withOpacity(0.12),
                         foregroundColor: theme.colorScheme.primary,
-                        backgroundImage: hasAdministrationParticipant
-                            ? const AssetImage('assets/icon/icon.png')
-                            : null,
-                        child: hasAdministrationParticipant
-                            ? null
-                            : Text(titleInitial),
+                        child: Text(titleInitial),
                       ),
                       title: Text(
                         displayTitle,

--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -126,16 +126,10 @@ class MessagingView extends GetView<MessagingController> {
                     children: [
                       CircleAvatar(
                         radius: 20,
-                        backgroundColor: hasAdministrationParticipant
-                            ? Colors.transparent
-                            : theme.colorScheme.primary.withOpacity(0.12),
+                        backgroundColor:
+                            theme.colorScheme.primary.withOpacity(0.12),
                         foregroundColor: theme.colorScheme.primary,
-                        backgroundImage: hasAdministrationParticipant
-                            ? const AssetImage('assets/icon/icon.png')
-                            : null,
-                        child: hasAdministrationParticipant
-                            ? null
-                            : Text(titleInitial),
+                        child: Text(titleInitial),
                       ),
                       const SizedBox(width: 12),
                       Expanded(

--- a/lib/modules/messaging/views/new_conversation_view.dart
+++ b/lib/modules/messaging/views/new_conversation_view.dart
@@ -290,7 +290,6 @@ class _NewConversationViewState extends State<NewConversationView> {
                       final showRelationshipChip = relationship != null &&
                           relationship.isNotEmpty &&
                           !shouldHideRelationship;
-                      final isAdminContact = normalizedRole == 'admin';
                       final initial = contact.name.isEmpty
                           ? '?'
                           : contact.name.characters.first.toUpperCase();
@@ -324,20 +323,16 @@ class _NewConversationViewState extends State<NewConversationView> {
                                 children: [
                                   CircleAvatar(
                                     radius: 28,
-                                    backgroundColor: accentColor.withOpacity(0.18),
+                                    backgroundColor:
+                                        accentColor.withOpacity(0.18),
                                     foregroundColor: accentColor,
-                                    backgroundImage: isAdminContact
-                                        ? const AssetImage('assets/icon/icon.png')
-                                        : null,
-                                    child: isAdminContact
-                                        ? null
-                                        : Text(
-                                            initial,
-                                            style: theme.textTheme.titleMedium
-                                                ?.copyWith(
-                                              fontWeight: FontWeight.w700,
-                                            ),
-                                          ),
+                                    child: Text(
+                                      initial,
+                                      style:
+                                          theme.textTheme.titleMedium?.copyWith(
+                                        fontWeight: FontWeight.w700,
+                                      ),
+                                    ),
                                   ),
                                   const SizedBox(width: 18),
                                   Expanded(


### PR DESCRIPTION
## Summary
- remove the special-case asset icon for administration participants across messaging views
- fall back to the standard initial-based avatar styling for all participants and contacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddefacb28c8331933b024f1f1761f1