### PR TITLE
Use branded icon for administration conversations

### DIFF
--- a/lib/modules/messaging/controllers/messaging_controller.dart
+++ b/lib/modules/messaging/controllers/messaging_controller.dart
@@ -351,6 +351,22 @@ class MessagingController extends GetxController {
   bool get isTeacher =>
       (_authService.currentRole ?? '').toLowerCase() == 'teacher';
 
+  bool get isParent =>
+      (_authService.currentRole ?? '').toLowerCase() == 'parent';
+
+  bool hasAdministrationParticipant(ConversationModel conversation) {
+    return conversation.participants.any(
+      (participant) => participant.role.toLowerCase() == 'admin',
+    );
+  }
+
+  bool shouldUseAdministrationAvatar(ConversationModel conversation) {
+    if (!isTeacher && !isParent) {
+      return false;
+    }
+    return hasAdministrationParticipant(conversation);
+  }
+
   bool get shouldShowAdministrationAction {
     if (!isTeacher) {
       return false;

--- a/lib/modules/messaging/views/conversation_history_view.dart
+++ b/lib/modules/messaging/views/conversation_history_view.dart
@@ -100,6 +100,8 @@ class ConversationHistoryView extends StatelessWidget {
                   final titleInitial = displayTitle.isEmpty
                       ? '?'
                       : displayTitle.characters.first.toUpperCase();
+                  final showAdministrationAvatar =
+                      controller.shouldUseAdministrationAvatar(conversation);
                   return AnimatedContainer(
                     duration: const Duration(milliseconds: 250),
                     curve: Curves.easeInOut,
@@ -123,10 +125,18 @@ class ConversationHistoryView extends StatelessWidget {
                         vertical: 12,
                       ),
                       leading: CircleAvatar(
-                        backgroundColor:
-                            theme.colorScheme.primary.withOpacity(0.12),
-                        foregroundColor: theme.colorScheme.primary,
-                        child: Text(titleInitial),
+                        backgroundColor: showAdministrationAvatar
+                            ? Colors.transparent
+                            : theme.colorScheme.primary.withOpacity(0.12),
+                        foregroundColor: showAdministrationAvatar
+                            ? Colors.transparent
+                            : theme.colorScheme.primary,
+                        backgroundImage: showAdministrationAvatar
+                            ? const AssetImage('assets/icon/icon.png')
+                            : null,
+                        child: showAdministrationAvatar
+                            ? null
+                            : Text(titleInitial),
                       ),
                       title: Text(
                         displayTitle,

--- a/lib/modules/messaging/views/messaging_view.dart
+++ b/lib/modules/messaging/views/messaging_view.dart
@@ -109,10 +109,10 @@ class MessagingView extends GetView<MessagingController> {
                   }
                   var titleText =
                       controller.resolveConversationTitle(activeConversation);
-                  final hasAdministrationParticipant = activeConversation
-                      .participants
-                      .any((participant) =>
-                          participant.role.toLowerCase() == 'admin');
+                  final hasAdministrationParticipant = controller
+                      .hasAdministrationParticipant(activeConversation);
+                  final showAdministrationAvatar = controller
+                      .shouldUseAdministrationAvatar(activeConversation);
                   if (hasAdministrationParticipant) {
                     titleText = 'Administration';
                   }
@@ -126,10 +126,17 @@ class MessagingView extends GetView<MessagingController> {
                     children: [
                       CircleAvatar(
                         radius: 20,
-                        backgroundColor:
-                            theme.colorScheme.primary.withOpacity(0.12),
-                        foregroundColor: theme.colorScheme.primary,
-                        child: Text(titleInitial),
+                        backgroundColor: showAdministrationAvatar
+                            ? Colors.transparent
+                            : theme.colorScheme.primary.withOpacity(0.12),
+                        foregroundColor: showAdministrationAvatar
+                            ? Colors.transparent
+                            : theme.colorScheme.primary,
+                        backgroundImage: showAdministrationAvatar
+                            ? const AssetImage('assets/icon/icon.png')
+                            : null,
+                        child:
+                            showAdministrationAvatar ? null : Text(titleInitial),
                       ),
                       const SizedBox(width: 12),
                       Expanded(


### PR DESCRIPTION
## Summary
- show the school icon in conversation lists and headers when teachers or parents view administration threads
- centralize the administration participant checks so the UI can reuse the same logic

## Testing
- not run (tooling unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68ddf19cb8d48331a5c6b79f75113609