### PR TITLE
Fix administration conversation avatar display

### DIFF
--- a/lib/modules/messaging/controllers/messaging_controller.dart
+++ b/lib/modules/messaging/controllers/messaging_controller.dart
@@ -361,10 +361,16 @@ class MessagingController extends GetxController {
   }
 
   bool shouldUseAdministrationAvatar(ConversationModel conversation) {
-    if (!isTeacher && !isParent) {
+    if (hasAdministrationParticipant(conversation)) {
+      return true;
+    }
+
+    final normalizedTitle = conversation.title.trim().toLowerCase();
+    if (normalizedTitle.isEmpty) {
       return false;
     }
-    return hasAdministrationParticipant(conversation);
+
+    return normalizedTitle.contains('admin');
   }
 
   bool get shouldShowAdministrationAction {


### PR DESCRIPTION
## Summary
- always show the administration avatar when a conversation includes an administration participant
- fall back to the conversation title to decide when to show the administration avatar if no participant metadata is available

## Testing
- `flutter test` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de01a0887c833197b079a4971b7e72