### PR TITLE
Use gradient background for role dashboard

### DIFF
--- a/lib/core/widgets/role_dashboard.dart
+++ b/lib/core/widgets/role_dashboard.dart
@@ -15,6 +15,7 @@ class RoleDashboard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
     return Scaffold(
       appBar: AppBar(
         title: Text('$roleName Dashboard'),
@@ -26,11 +27,16 @@ class RoleDashboard extends StatelessWidget {
           ),
         ],
       ),
-      body: Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage('assets/splash/background.png'),
-            fit: BoxFit.cover,
+      body: DecoratedBox(
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              colorScheme.primary.withOpacity(0.12),
+              colorScheme.secondary.withOpacity(0.08),
+              colorScheme.surface,
+            ],
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
           ),
         ),
         child: GridView.count(


### PR DESCRIPTION
## Summary
- replace the role dashboard background image with a theme-aware gradient so no asset changes are required

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de040438a8833193aed0a81fb7007b