### PR TITLE
Handle missing assets gracefully

### DIFF
--- a/lib/core/widgets/role_dashboard.dart
+++ b/lib/core/widgets/role_dashboard.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../core/widgets/dashboard_card.dart';
+import 'safe_asset_image.dart';
 
 class RoleDashboard extends StatelessWidget {
   final List<DashboardCard> cards;
@@ -26,21 +27,25 @@ class RoleDashboard extends StatelessWidget {
           ),
         ],
       ),
-      body: Container(
-        decoration: const BoxDecoration(
-          image: DecorationImage(
-            image: AssetImage('assets/splash/background.png'),
+      body: Stack(
+        fit: StackFit.expand,
+        children: [
+          SafeAssetImage(
+            assetPath: 'assets/splash/background.png',
             fit: BoxFit.cover,
+            fallback: Container(
+              color: Theme.of(context).colorScheme.surface,
+            ),
           ),
-        ),
-        child: GridView.count(
-          padding: const EdgeInsets.all(16),
-          crossAxisCount: 2,
-          mainAxisSpacing: 16,
-          crossAxisSpacing: 16,
-          childAspectRatio: 1.1,
-          children: cards,
-        ),
+          GridView.count(
+            padding: const EdgeInsets.all(16),
+            crossAxisCount: 2,
+            mainAxisSpacing: 16,
+            crossAxisSpacing: 16,
+            childAspectRatio: 1.1,
+            children: cards,
+          ),
+        ],
       ),
     );
   }

--- a/lib/core/widgets/safe_asset_image.dart
+++ b/lib/core/widgets/safe_asset_image.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+/// A safe wrapper around [Image.asset] that provides a graceful fallback
+/// when the asset cannot be loaded (for example when the image file isn't
+/// available in the build).
+class SafeAssetImage extends StatelessWidget {
+  final String assetPath;
+  final BoxFit fit;
+  final Alignment alignment;
+  final Widget? fallback;
+
+  const SafeAssetImage({
+    super.key,
+    required this.assetPath,
+    this.fit = BoxFit.contain,
+    this.alignment = Alignment.center,
+    this.fallback,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Image.asset(
+      assetPath,
+      fit: fit,
+      alignment: alignment,
+      errorBuilder: (context, _, __) {
+        if (fallback != null) {
+          return fallback!;
+        }
+        return Container(
+          alignment: alignment,
+          color: Theme.of(context).colorScheme.surface,
+        );
+      },
+    );
+  }
+}

--- a/lib/modules/auth/views/login_view.dart
+++ b/lib/modules/auth/views/login_view.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
+import '../../../core/widgets/safe_asset_image.dart';
 import '../controllers/auth_controller.dart';
 
 class LoginView extends StatelessWidget {
@@ -15,91 +16,68 @@ class LoginView extends StatelessWidget {
     return GestureDetector(
       onTap: _authController.unfocusFields,
       child: Scaffold(
-        body: Container(
-          decoration: const BoxDecoration(
-            image: DecorationImage(
-              image: AssetImage('assets/splash/background.png'),
+        body: Stack(
+          fit: StackFit.expand,
+          children: [
+            SafeAssetImage(
+              assetPath: 'assets/splash/background.png',
               fit: BoxFit.cover,
+              fallback: Container(
+                color: Theme.of(context).colorScheme.surface,
+              ),
             ),
-          ),
-          child: Center(
-            child: SingleChildScrollView(
-              padding: const EdgeInsets.all(24),
-              child: ConstrainedBox(
-                constraints: const BoxConstraints(maxWidth: 400),
-                child: Column(
-                  mainAxisAlignment: MainAxisAlignment.center,
-                  children: [
-                    Image.asset('assets/EduMS_logo.png', width: 200, height: 200),
-                    const SizedBox(height: 40),
-                    Card(
-                      elevation: 2,
-                      shape: RoundedRectangleBorder(
-                        borderRadius: BorderRadius.circular(16),
+            Center(
+              child: SingleChildScrollView(
+                padding: const EdgeInsets.all(24),
+                child: ConstrainedBox(
+                  constraints: const BoxConstraints(maxWidth: 400),
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      SizedBox(
+                        width: 200,
+                        height: 200,
+                        child: SafeAssetImage(
+                          assetPath: 'assets/EduMS_logo.png',
+                          fallback: Icon(
+                            Icons.school,
+                            size: 120,
+                            color: Theme.of(context).colorScheme.primary,
+                          ),
+                        ),
                       ),
-                      child: Padding(
-                        padding: const EdgeInsets.all(24),
-                        child: Column(
-                          children: [
-                            Text(
-                              'Login',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .headlineMedium
-                                  ?.copyWith(
-                                    fontWeight: FontWeight.bold,
-                                    color: Theme.of(context).colorScheme.primary,
-                                  ),
-                            ),
-                            const SizedBox(height: 24),
-                            TextField(
-                              controller: _authController.emailController,
-                              focusNode: _authController.emailFocus,
-                              decoration: InputDecoration(
-                                labelText: 'Email',
-                                prefixIcon: Icon(
-                                  Icons.email,
-                                  color:
-                                      Theme.of(context).colorScheme.onSurfaceVariant,
-                                ),
-                                border: OutlineInputBorder(
-                                  borderRadius: BorderRadius.circular(12),
-                                ),
-                                filled: true,
-                                fillColor: Theme.of(context)
-                                    .colorScheme
-                                    .surfaceVariant
-                                    .withOpacity(0.4),
+                      const SizedBox(height: 40),
+                      Card(
+                        elevation: 2,
+                        shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(16),
+                        ),
+                        child: Padding(
+                          padding: const EdgeInsets.all(24),
+                          child: Column(
+                            children: [
+                              Text(
+                                'Login',
+                                style: Theme.of(context)
+                                    .textTheme
+                                    .headlineMedium
+                                    ?.copyWith(
+                                      fontWeight: FontWeight.bold,
+                                      color:
+                                          Theme.of(context).colorScheme.primary,
+                                    ),
                               ),
-                              keyboardType: TextInputType.emailAddress,
-                              textInputAction: TextInputAction.next,
-                              onSubmitted: (_) =>
-                                  _authController.passwordFocus.requestFocus(),
-                            ),
-                            const SizedBox(height: 16),
-                            Obx(
-                              () => TextField(
-                                controller: _authController.passwordController,
-                                focusNode: _authController.passwordFocus,
-                                obscureText: _obscurePassword.value,
+                              const SizedBox(height: 24),
+                              TextField(
+                                controller: _authController.emailController,
+                                focusNode: _authController.emailFocus,
                                 decoration: InputDecoration(
-                                  labelText: 'Password',
+                                  labelText: 'Email',
                                   prefixIcon: Icon(
-                                    Icons.lock,
+                                    Icons.email,
                                     color: Theme.of(context)
                                         .colorScheme
                                         .onSurfaceVariant,
-                                  ),
-                                  suffixIcon: IconButton(
-                                    icon: Icon(
-                                      _obscurePassword.value
-                                          ? Icons.visibility
-                                          : Icons.visibility_off,
-                                      color: Theme.of(context)
-                                          .colorScheme
-                                          .onSurfaceVariant,
-                                    ),
-                                    onPressed: () => _obscurePassword.toggle(),
                                   ),
                                   border: OutlineInputBorder(
                                     borderRadius: BorderRadius.circular(12),
@@ -110,48 +88,89 @@ class LoginView extends StatelessWidget {
                                       .surfaceVariant
                                       .withOpacity(0.4),
                                 ),
-                                textInputAction: TextInputAction.done,
-                                onSubmitted: (_) => _authController.submitForm(),
+                                keyboardType: TextInputType.emailAddress,
+                                textInputAction: TextInputAction.next,
+                                onSubmitted: (_) =>
+                                    _authController.passwordFocus.requestFocus(),
                               ),
-                            ),
-                            const SizedBox(height: 24),
-                            Obx(
-                              () => FilledButton(
-                                style: FilledButton.styleFrom(
-                                  backgroundColor:
-                                      Theme.of(context).colorScheme.primary,
-                                  foregroundColor:
-                                      Theme.of(context).colorScheme.onPrimary,
-                                  minimumSize: const Size(double.infinity, 50),
-                                  shape: RoundedRectangleBorder(
-                                    borderRadius: BorderRadius.circular(12),
+                              const SizedBox(height: 16),
+                              Obx(
+                                () => TextField(
+                                  controller: _authController.passwordController,
+                                  focusNode: _authController.passwordFocus,
+                                  obscureText: _obscurePassword.value,
+                                  decoration: InputDecoration(
+                                    labelText: 'Password',
+                                    prefixIcon: Icon(
+                                      Icons.lock,
+                                      color: Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
+                                    ),
+                                    suffixIcon: IconButton(
+                                      icon: Icon(
+                                        _obscurePassword.value
+                                            ? Icons.visibility
+                                            : Icons.visibility_off,
+                                        color: Theme.of(context)
+                                            .colorScheme
+                                            .onSurfaceVariant,
+                                      ),
+                                      onPressed: () => _obscurePassword.toggle(),
+                                    ),
+                                    border: OutlineInputBorder(
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                    filled: true,
+                                    fillColor: Theme.of(context)
+                                        .colorScheme
+                                        .surfaceVariant
+                                        .withOpacity(0.4),
                                   ),
+                                  textInputAction: TextInputAction.done,
+                                  onSubmitted: (_) =>
+                                      _authController.submitForm(),
                                 ),
-                                onPressed: _authController.isLoading.value
-                                    ? null
-                                    : _authController.submitForm,
-                                child: _authController.isLoading.value
-                                    ? const SizedBox(
-                                        height: 24,
-                                        width: 24,
-                                        child: CircularProgressIndicator(
-                                          strokeWidth: 2,
-                                          color: Colors.white,
-                                        ),
-                                      )
-                                    : const Text('Login',
-                                        style: TextStyle(fontSize: 16)),
                               ),
-                            ),
-                          ],
+                              const SizedBox(height: 24),
+                              Obx(
+                                () => FilledButton(
+                                  style: FilledButton.styleFrom(
+                                    backgroundColor:
+                                        Theme.of(context).colorScheme.primary,
+                                    foregroundColor:
+                                        Theme.of(context).colorScheme.onPrimary,
+                                    minimumSize: const Size(double.infinity, 50),
+                                    shape: RoundedRectangleBorder(
+                                      borderRadius: BorderRadius.circular(12),
+                                    ),
+                                  ),
+                                  onPressed: _authController.isLoading.value
+                                      ? null
+                                      : _authController.submitForm,
+                                  child: _authController.isLoading.value
+                                      ? const SizedBox(
+                                          height: 24,
+                                          width: 24,
+                                          child: CircularProgressIndicator(
+                                            strokeWidth: 2,
+                                            color: Colors.white,
+                                          ),
+                                        )
+                                      : const Text('Login',
+                                          style: TextStyle(fontSize: 16)),
+                                ),
+                              ),
+                            ],
+                          ),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 ),
               ),
             ),
-          ),
+          ],
         ),
       ),
     );

--- a/lib/modules/splash/splash_view.dart
+++ b/lib/modules/splash/splash_view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../../core/widgets/safe_asset_image.dart';
 import '../../../app/routes/app_pages.dart';
 
 class SplashView extends StatefulWidget {
@@ -69,9 +70,12 @@ class _SplashViewState extends State<SplashView> {
         fit: StackFit.expand,
         children: [
           // Background image
-          Image.asset(
-            'assets/splash/background.png',
+          SafeAssetImage(
+            assetPath: 'assets/splash/background.png',
             fit: BoxFit.cover,
+            fallback: Container(
+              color: Theme.of(context).colorScheme.surface,
+            ),
           ),
 
           // Content
@@ -80,10 +84,14 @@ class _SplashViewState extends State<SplashView> {
               mainAxisAlignment: MainAxisAlignment.center,
               children: [
                 // Your logo
-                Image.asset(
-                  'assets/EduMS_logo.png',
-                  width: 200,
-                  height: 200,
+                SafeAssetImage(
+                  assetPath: 'assets/EduMS_logo.png',
+                  fit: BoxFit.contain,
+                  fallback: Icon(
+                    Icons.school,
+                    size: 120,
+                    color: Theme.of(context).colorScheme.primary,
+                  ),
                 ),
                 SizedBox(height: 20),
                 // Loading indicator
@@ -109,9 +117,18 @@ class _SplashViewState extends State<SplashView> {
                       fontWeight: FontWeight.w500,
                     ),
                   ),
-                  Image.asset(
-                    'assets/Denet_logo.png',
+                  SizedBox(
                     height: 40,
+                    child: SafeAssetImage(
+                      assetPath: 'assets/Denet_logo.png',
+                      fit: BoxFit.contain,
+                      fallback: Text(
+                        'Denet',
+                        style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                      ),
+                    ),
                   ),
                 ],
               ),


### PR DESCRIPTION
## Summary
- add a SafeAssetImage widget that wraps Image.asset and displays a fallback when an asset is missing
- update the splash, login, and dashboard screens to use the safe loader for background and logo images

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de05cf5db8833184060092445fd6a6